### PR TITLE
Ignore None in data configuration variables

### DIFF
--- a/nbs/01_io.ipynb
+++ b/nbs/01_io.ipynb
@@ -615,9 +615,9 @@
     "    \n",
     "    # Perform transformation and filtering\n",
     "    globs = {'pd':pd, 'np':np, 'stk':stk, 'df':df, **constants}\n",
-    "    if 'preprocessing' in desc:  exec(desc['preprocessing'], globs)\n",
-    "    if 'filter' in desc: globs['df'] = globs['df'][eval(desc['filter'], globs)]\n",
-    "    if 'postprocessing' in desc and not skip_postprocessing: exec(desc['postprocessing'],globs)\n",
+    "    if desc.get('preprocessing'): exec(desc['preprocessing'], globs)\n",
+    "    if desc.get('filter'): globs['df'] = globs['df'][eval(desc['filter'], globs)]\n",
+    "    if desc.get('postprocessing') and not skip_postprocessing: exec(desc['postprocessing'],globs)\n",
     "    df = globs['df']\n",
     "    \n",
     "    return (df, meta) if return_meta else df"

--- a/salk_toolkit/io.py
+++ b/salk_toolkit/io.py
@@ -494,9 +494,9 @@ def read_and_process_data(desc, return_meta=False, constants={}, skip_postproces
     
     # Perform transformation and filtering
     globs = {'pd':pd, 'np':np, 'stk':stk, 'df':df, **constants}
-    if 'preprocessing' in desc:  exec(desc['preprocessing'], globs)
-    if 'filter' in desc: globs['df'] = globs['df'][eval(desc['filter'], globs)]
-    if 'postprocessing' in desc and not skip_postprocessing: exec(desc['postprocessing'],globs)
+    if desc.get('preprocessing'): exec(desc['preprocessing'], globs)
+    if desc.get('filter'): globs['df'] = globs['df'][eval(desc['filter'], globs)]
+    if desc.get('postprocessing') and not skip_postprocessing: exec(desc['postprocessing'],globs)
     df = globs['df']
     
     return (df, meta) if return_meta else df


### PR DESCRIPTION
Sometimes, the 'preprocessing', 'postprocessing' and 'filter' can take default values of None. Do not run these processing steps if the variable is None.