### PR TITLE
Add Kaido's fix for  plot type in streamlit>1.47

### DIFF
--- a/salk_toolkit/plots.py
+++ b/salk_toolkit/plots.py
@@ -1166,6 +1166,9 @@ def _cat_to_cont_axis(
         data = data.sort_values(cont_col)
         return x_axis, data
 
+    if order:
+        data[col] = pd.Categorical(data[col], categories=order, ordered=True)
+        data = data.sort_values(col)
     # Default: keep nominal categorical axis.
     x_axis = alt.X(field=col, type="nominal", title=None, sort=order, axis=alt.Axis(labelAngle=0))
     return x_axis, data


### PR DESCRIPTION
There was a change in how a dataframe is ordered by streamlit before in 1.47.0 plotting and now in 1.52.0 we have to explicitly sort the dataframe by the category order.