### PR TITLE
Add two new plot workflows

### DIFF
--- a/salk_toolkit/pp.py
+++ b/salk_toolkit/pp.py
@@ -1850,9 +1850,14 @@ def create_plot(
     return plot
 
 
+# Extra configuration for plots in publish mode
+publish_spec = {"config": {"legend": {"labelLimit": 0}, "axis": {"labelLimit": 0}}}
+
+
 def _apply_publish_mode(plot: AltairChart) -> AltairChart:
     """Apply publish mode to the plot."""
-    return plot.configure_legend(labelLimit=0).configure_axis(labelLimit=0)
+    spec = utils.recursive_dict_merge(plot.to_dict(), publish_spec)
+    return type(plot).from_dict(spec)
 
 
 def impute_factor_cols(

--- a/salk_toolkit/pp.py
+++ b/salk_toolkit/pp.py
@@ -1568,6 +1568,7 @@ def create_plot(
     height: int | None = None,
     return_matrix_of_plots: bool = False,
     translate: Callable[[str], str] | None = None,
+    publish_mode: bool = False,
 ) -> AltairChart | List[List[AltairChart]] | PlotInput:
     """Produce an Altair plot (or matrix of plots) from prepared parameters.
 
@@ -1759,6 +1760,10 @@ def create_plot(
     if alt_wrapper is None:
         alt_wrapper = lambda p: p
 
+    if publish_mode:
+        old_alt_wrapper = alt_wrapper
+        alt_wrapper = lambda p: old_alt_wrapper(_apply_publish_mode(p))
+
     plot_arg_payload = clean_kwargs(plot_fn, plot_args)
 
     def _call_plot_fn(
@@ -1843,6 +1848,11 @@ def create_plot(
             plot = [[plot]]
 
     return plot
+
+
+def _apply_publish_mode(plot: AltairChart) -> AltairChart:
+    """Apply publish mode to the plot."""
+    return plot.configure_legend(labelLimit=0).configure_axis(labelLimit=0)
 
 
 def impute_factor_cols(

--- a/salk_toolkit/tools/explorer.py
+++ b/salk_toolkit/tools/explorer.py
@@ -445,6 +445,7 @@ with st.sidebar:  # .expander("Select dimensions"):
     )
 
     # Export options
+    publish_mode = False
     with st.expander("Export"):
         width = None
         height = None
@@ -457,6 +458,7 @@ with st.sidebar:  # .expander("Select dimensions"):
                 width = st.slider("Width", value=800, min_value=100, max_value=1200, step=50)
                 height = st.slider("Height", value=600, min_value=100, max_value=2500, step=50)
             st.subheader("Export")
+            publish_mode = st.toggle("Publish mode", value=False)
             export_ct = st.container()
 
     # print(list(st.session_state.keys()))
@@ -537,6 +539,7 @@ elif input_files_facet:
         width=(width or get_plot_width("full", 1)),
         height=height,
         return_matrix_of_plots=matrix_form,
+        publish_mode=publish_mode,
     )
 
     draw_plot_matrix(plot)
@@ -574,6 +577,7 @@ else:
                 width=cur_width,
                 height=height,
                 return_matrix_of_plots=matrix_form,
+                publish_mode=publish_mode,
             )
 
             # n_questions = pi['data']['question'].nunique() if 'question' in pi['data'] else 1

--- a/salk_toolkit/tools/explorer.py
+++ b/salk_toolkit/tools/explorer.py
@@ -103,7 +103,6 @@ with st.spinner("Loading libraries.."):
     import os
     import sys
     import warnings
-    from altair.utils._importers import import_vl_convert
     from collections import defaultdict
     from copy import deepcopy
     from typing import TypeVar
@@ -114,6 +113,7 @@ with st.spinner("Loading libraries.."):
     import psutil
     import streamlit.components.v1 as components
     from streamlit_js import st_js, st_js_blocking  # type: ignore[import-untyped]
+    from altair.utils._importers import import_vl_convert
 
     from salk_toolkit.dashboard import (
         default_translate,
@@ -136,7 +136,7 @@ with st.spinner("Loading libraries.."):
         matching_plots,
         pp_transform_data,
     )
-    from salk_toolkit.utils import apply_standard_chart_config, plot_matrix_html, replace_constants
+    from salk_toolkit.utils import chart_to_url_with_config, plot_matrix_html, replace_constants
     from salk_toolkit.validation import DataMeta, PlotDescriptor, soft_validate
 
     T = TypeVar("T")
@@ -157,29 +157,6 @@ def get_plot_width(width_str: str, ncols: int = 1) -> int:
     Calculate plot width based on number of columns.
     """
     return min(800, int(1200 / ncols))
-
-
-def chart_to_url_with_config(chart: alt.Chart | alt.LayerChart | alt.FacetChart | object) -> str:
-    """Convert an Altair chart to a Vega editor URL with standard configuration.
-
-    This ensures the Vega editor shows the same styling and configuration
-    as the Streamlit display and HTML exports.
-
-    Args:
-        chart: Altair chart object (Chart, LayerChart, FacetChart, etc.).
-
-    Returns:
-        URL string for opening the chart in the Vega editor.
-    """
-    vlc = import_vl_convert()
-
-    # Convert chart to dict and apply standard configuration
-    chart_dict = json.loads(chart.to_json())  # type: ignore[attr-defined]
-    chart_dict = apply_standard_chart_config(chart_dict)
-
-    # Use vl-convert to build the URL with our configured spec
-    # This avoids validation issues and matches Altair's encoding
-    return vlc.vegalite_to_url(chart_dict, fullscreen=False)
 
 
 if "ls_loaded" not in st.session_state:

--- a/salk_toolkit/utils.py
+++ b/salk_toolkit/utils.py
@@ -67,6 +67,7 @@ __all__ = [
     "unescape_vega_label",
     "warn",
     "plot_matrix_html",
+    "chart_to_url_with_config",
 ]
 
 import json
@@ -104,6 +105,8 @@ import pandas as pd
 import scipy
 from scipy.optimize import linear_sum_assignment
 from scipy.spatial.distance import cdist
+
+from altair.utils._importers import import_vl_convert
 
 import altair as alt
 import matplotlib.colors as mpc
@@ -1223,6 +1226,29 @@ def apply_standard_chart_config(chart_dict: dict[str, Any]) -> dict[str, Any]:
     embedOptions["actions"] = {"export": True, "source": False, "editor": False, "compiled": False}
 
     return chart_dict
+
+
+def chart_to_url_with_config(chart: alt.Chart | alt.LayerChart | alt.FacetChart | object) -> str:
+    """Convert an Altair chart to a Vega editor URL with standard configuration.
+
+    This ensures the Vega editor shows the same styling and configuration
+    as the Streamlit display and HTML exports.
+
+    Args:
+        chart: Altair chart object (Chart, LayerChart, FacetChart, etc.).
+
+    Returns:
+        URL string for opening the chart in the Vega editor.
+    """
+    vlc = import_vl_convert()
+
+    # Convert chart to dict and apply standard configuration
+    chart_dict = json.loads(chart.to_json())  # type: ignore[attr-defined]
+    chart_dict = apply_standard_chart_config(chart_dict)
+
+    # Use vl-convert to build the URL with our configured spec
+    # This avoids validation issues and matches Altair's encoding
+    return vlc.vegalite_to_url(chart_dict, fullscreen=False)
 
 
 # HTML template for embedding Altair plots

--- a/salk_toolkit/utils.py
+++ b/salk_toolkit/utils.py
@@ -1080,6 +1080,7 @@ def read_yaml(model_desc_file: str) -> JSONValue:
 
 
 # Altair default configuration for plot styling
+# Largely borrowed from streamlit to match their styling
 altair_default_config = {
     "font": '"Source Sans Pro", sans-serif',
     "background": "#ffffff",
@@ -1136,11 +1137,11 @@ altair_default_config = {
         "titleFontWeight": 400,
         "titleFontStyle": "normal",
         "titleColor": "#808495",
-        "titlePadding": 5,
-        "labelPadding": 16,
+        "titlePadding": 4,
+        "labelPadding": 9,
         "columnPadding": 8,
         "rowPadding": 4,
-        "padding": 7,
+        "padding": 8,
         "symbolStrokeWidth": 4,
     },
     "range": {
@@ -1203,13 +1204,72 @@ altair_default_config = {
     },
     "concat": {"columns": 1},
     "facet": {"columns": 1},
-    "mark": {"tooltip": True, "color": "#0068c9"},
+    "mark": {"tooltip": {"content": "encoding"}, "color": "#0068c9"},
     "bar": {"binSpacing": 4, "discreteBandSize": {"band": 0.85}},
     "axisDiscrete": {"grid": False},
     "axisXPoint": {"grid": False},
     "axisTemporal": {"grid": False},
     "axisXBand": {"grid": False},
 }
+
+# Dark mode: overrides for `altair_default_config` (apply via `recursive_dict_merge`).
+altair_dark_config = recursive_dict_merge(
+    altair_default_config,
+    {
+        "background": "#0e1117",
+        "title": {"color": "#fafafa"},
+        "header": {"titleColor": "#e6eaf1", "labelColor": "#e6eaf1"},
+        "axis": {
+            "labelColor": "#e6eaf1",
+            "titleColor": "#e6eaf1",
+            "gridColor": "#31333F",
+            "domainColor": "#31333F",
+        },
+        "legend": {
+            "labelColor": "#e6eaf1",
+            "titleColor": "#e6eaf1",
+        },
+        "range": {
+            "category": [
+                "#83c9ff",
+                "#0068c9",
+                "#ffabab",
+                "#ff2b2b",
+                "#7defa1",
+                "#29b09d",
+                "#ffd16a",
+                "#ff8700",
+                "#6d3fc0",
+                "#d5dae5",
+            ],
+            "ramp": [
+                "#004280",
+                "#0054a3",
+                "#0068c9",
+                "#1c83e1",
+                "#3d9df3",
+                "#60b4ff",
+                "#83c9ff",
+                "#a6dcff",
+                "#c7ebff",
+                "#e4f5ff",
+            ],
+            "heatmap": [
+                "#004280",
+                "#0054a3",
+                "#0068c9",
+                "#1c83e1",
+                "#3d9df3",
+                "#60b4ff",
+                "#83c9ff",
+                "#a6dcff",
+                "#c7ebff",
+                "#e4f5ff",
+            ],
+        },
+        "mark": {"color": "#83c9ff"},
+    },
+)
 
 
 def apply_standard_chart_config(chart_dict: dict[str, Any]) -> dict[str, Any]:
@@ -1225,8 +1285,14 @@ def apply_standard_chart_config(chart_dict: dict[str, Any]) -> dict[str, Any]:
     Returns:
         Modified chart dictionary with standard configuration applied.
     """
+
+    import streamlit as st
+
+    config = altair_default_config
+    if st.context.theme.type == "dark":
+        config = altair_dark_config
     # Apply visual styling configuration without overriding existing config if present
-    chart_dict["config"] = recursive_dict_merge(altair_default_config, chart_dict.get("config", {}))
+    chart_dict["config"] = recursive_dict_merge(config, chart_dict.get("config", {}))
 
     # Apply embed options for high-quality rendering
     chart_dict.setdefault("usermeta", {}).setdefault("embedOptions", {})


### PR DESCRIPTION
a) Make it easy to get a plot from dashboards if needed
Added an export flag to st.plot that, when true, adds an edit button next to plot. Clicking it sends to vega editor with that plot. Redirect would have likely been better here, but is annoyingly complex in streamlit

b) Add a "publish mode" that uses a different conf and allows for variations in pp as well.
It is a checkbox in explorer that is passed to create_plot. Currently only feeds in a small config change, but feeding it there allows for more complex things, like messing with translations and changing around category names etc. 