### PR TITLE
Spec config example

### DIFF
--- a/salk_toolkit/plots.py
+++ b/salk_toolkit/plots.py
@@ -1484,7 +1484,6 @@ def lines(
         raise ValueError("lines plot requires at least one facet dimension")
 
     fmt = p.val_format or ".2f"
-    chart_width = p.width
     if len(p.facets) == 1:
         fx = p.facets[0]
         fy = None
@@ -1497,46 +1496,55 @@ def lines(
 
     # See if we should use a continous axis (if categoricals are actually numbers)
     x_axis, data = _cat_to_cont_axis(data, fx)
-
+    num_columns = estimate_legend_columns_horiz(fy.order, p.width) if fy else 1
     chart = alt.Chart(data)
-    plot = chart.mark_line(point=True, interpolate=smooth).encode(
-        x=x_axis,
-        y=alt.Y(
-            field=p.value_col,
-            type="quantitative",
-            title=(p.value_col if len(p.value_col) < 20 else None),
-            axis=alt.Axis(format=fmt),
-        ),
-        tooltip=p.tooltip,
-        **(
+    title = p.value_col if len(p.value_col) < 20 else None
+
+    color_spec = None
+    if fy:
+        color_spec = {
+            "field": fy.col,
+            "type": "nominal",
+            "legend": {"orient": "top", "columns": num_columns},
+        }
+        if (colors := fy.colors) is not None and hasattr(colors, "domain"):
+            color_spec["scale"] = colors.to_dict() if hasattr(colors, "to_dict") else colors
+            color_spec["sort"] = fy.order
+
+    # Built as a plain dict spec (rather than the Altair encoding API) as an example of the
+    # JSON/Vega-Lite-spec-driven config style some users may prefer.
+    tooltip = [t.to_dict() if hasattr(t, "to_dict") else t for t in p.tooltip]
+    lines_plot_spec = {
+        "config": {
+            "line": {"point": True},
+        },
+        "layer": [
             {
-                "color": alt.Color(
-                    field=fy.col,
-                    type="nominal",
-                    scale=fy.colors,
-                    sort=fy.order,
-                    legend=alt.Legend(
-                        orient="top",
-                        columns=estimate_legend_columns_horiz(fy.order, chart_width),
-                    ),
-                )
-            }
-            if fy is not None
-            else {}
-        ),
-    )
+                "mark": {"type": "line", "interpolate": smooth, "point": True},
+                "encoding": {
+                    "x": x_axis.to_dict(),
+                    "y": {"field": p.value_col, "type": "quantitative", "axis": {"format": fmt}, "title": title},
+                    **({"color": color_spec} if color_spec else {}),
+                    "tooltip": tooltip,
+                },
+            },
+            {
+                "mark": {"type": "point", "size": 200, "opacity": 0},
+                "encoding": {
+                    "x": x_axis.to_dict(),
+                    "y": {"field": p.value_col, "type": "quantitative", "title": None},
+                    "tooltip": tooltip,
+                },
+            },
+        ],
+    }
 
-    # Add larger area for tooltip
-    plot += chart.mark_point(size=200, opacity=0).encode(
-        x=x_axis,
-        y=alt.Y(
-            field=p.value_col,
-            type="quantitative",
-            title=None,
-        ),
-        tooltip=p.tooltip,
-    )
-
+    # Use validate=False to avoid error due to missing mark/layer in base chart
+    plot_dict = chart.to_dict(validate=False)
+    merged_spec = utils.recursive_dict_merge(plot_dict, lines_plot_spec)
+    plot = alt.LayerChart.from_dict(merged_spec)
+    plot.data = data  # from_dict() inlines data as a dict; restore the live frame for payload extraction
+    assert plot.to_dict(validate=True)
     return plot
 
 

--- a/salk_toolkit/pp/__init__.py
+++ b/salk_toolkit/pp/__init__.py
@@ -42,6 +42,7 @@ from .registry import (
     registry as registry,
     registry_meta as registry_meta,
     stk_plot as stk_plot,
+    style as style,
     get_plot_fn as get_plot_fn,
     get_plot_meta as get_plot_meta,
     _ensure_plot_registry_loaded as _ensure_plot_registry_loaded,

--- a/salk_toolkit/pp/plotting.py
+++ b/salk_toolkit/pp/plotting.py
@@ -441,6 +441,13 @@ def create_plot(
         if return_matrix_of_plots:
             plot = [[plot]]
 
+    if hasattr(plot, "to_dict") and hasattr(plot_fn, "_stk_style"):
+        for style_name in getattr(plot_fn, "_stk_style", []):
+            s_dict = utils.get_style(style_name)
+            if s_dict:
+                merged = utils.recursive_dict_merge(plot.to_dict(), s_dict)
+                plot = type(plot).from_dict(merged)
+
     return plot
 
 

--- a/salk_toolkit/pp/registry.py
+++ b/salk_toolkit/pp/registry.py
@@ -87,6 +87,18 @@ def _ensure_plot_args_sync(func: Callable[..., Any], decorator_kwargs: Dict[str,
         )
 
 
+def style(style_name: str) -> Callable[[Callable[..., object]], Callable[..., object]]:
+    """Decorator to attach a style configuration to a plot function."""
+
+    def _decorator(gfunc: Callable[..., object]) -> Callable[..., object]:
+        if not hasattr(gfunc, "_stk_style"):
+            gfunc._stk_style = []  # type: ignore[attr-defined]
+        gfunc._stk_style.append(style_name)  # type: ignore[attr-defined]
+        return gfunc
+
+    return _decorator
+
+
 def stk_plot(plot_name: str, **r_kwargs: object) -> Callable[[Callable[..., object]], Callable[..., object]]:
     """Register a plotting function inside the global plot registry."""
 

--- a/salk_toolkit/utils.py
+++ b/salk_toolkit/utils.py
@@ -200,7 +200,7 @@ def merge_pydantic_models_recursive(
     return cls.model_validate(merged, context=context)
 
 
-def recursive_dict_merge(d1: object, d2: object) -> object:
+def recursive_dict_merge(d1: dict[str, Any], d2: dict[str, Any]) -> dict[str, Any]:
     """Recursively merge two nested dict-like structures, preferring values from `d2`."""
     if isinstance(d1, dict) and isinstance(d2, dict):
         comb = {**d1, **d2}

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -558,6 +558,20 @@ class TestPlots:
         }
         self._run_plot_test("test_lines_date", config, recompute=recompute)
 
+    def test_lines_single_facet_has_no_color_encoding(self) -> None:
+        """Single facet dim = no `fy` (color) split; the dict-spec build must omit `color`, not send a null field."""
+        config = {"res_col": "wave", "facet_dims": ["td"], "plot": "lines", "filter": {}}
+        from salk_toolkit.pp import create_plot, pp_transform_data
+
+        ldf, full_meta = read_parquet_with_metadata(str(self.data_file), lazy=True)
+        assert full_meta is not None and full_meta.data is not None
+        ppd = soft_validate(config, PlotDescriptor)
+        pi = create_plot(pp_transform_data(ldf, full_meta.data, ppd), ppd, dry_run=True, width=400)
+        assert isinstance(pi, PlotInput) and len(pi.facets) == 1
+        chart = get_plot_fn("lines")(pi)
+        assert "color" not in chart.to_dict()["layer"][0]["encoding"]
+        assert chart.to_dict(validate=True)  # would raise if a null-field color spec slipped through
+
     def test_lines_hdi_basic(self, recompute):
         """Test HDI line plot."""
         config = {


### PR DESCRIPTION
Using JSONs or dicts may make more sense if users are using Vega specs to configure charts.