### PR TITLE
Fix data meta warnings

### DIFF
--- a/salk_toolkit/plots.py
+++ b/salk_toolkit/plots.py
@@ -2019,7 +2019,7 @@ def _linevals(
     data_format="raw",
     factor_columns=3,
     aspect_ratio=(1.0 / 1.0),
-    plot_args={"group_categories": "bool", "full_data": "bool"},
+    args={"group_categories": "bool", "full_data": "bool"},
     n_facets=(0, 1),
     no_question_facet=True,
 )

--- a/salk_toolkit/pp.py
+++ b/salk_toolkit/pp.py
@@ -234,6 +234,7 @@ class PlotMeta(PBase):
     continuous: bool = False
     n_facets: Optional[Tuple[int, int]] = None
     requires: List[Dict[str, Any]] = DF(list)
+    requires_factor: bool = False
     no_question_facet: bool = False
     agg_fn: Optional[str] = None
     sample: Optional[int] = None

--- a/salk_toolkit/utils.py
+++ b/salk_toolkit/utils.py
@@ -136,7 +136,10 @@ def merge_pydantic_models(
     if defaults is None:
         return overrides
 
-    defaults_dict = defaults.model_dump(mode="python")
+    target_fields = overrides.__class__.model_fields
+    # Only carry over defaults fields that exist on the target model; this prevents
+    # scale-only fields (e.g. question_colors) from leaking into ColumnMeta instances.
+    defaults_dict = {k: v for k, v in defaults.model_dump(mode="python").items() if k in target_fields}
     # Important semantic: fields explicitly set on the override should replace defaults,
     # including explicit `None` (JSON `null`) which should clear inherited values.
     #

--- a/salk_toolkit/validation.py
+++ b/salk_toolkit/validation.py
@@ -55,6 +55,9 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    get_args,
+    get_origin,
+    get_type_hints,
     TypeAlias,
 )
 from pydantic import (
@@ -77,8 +80,7 @@ DF = lambda dc: Field(default_factory=dc)
 Scalar: TypeAlias = str | int | float | bool | None
 
 
-# Define a new base that ignores extra fields by default (for backward compatibility)
-# Warnings about extra fields are generated via soft_validate
+# Base model that ignores extra fields; strict checking is done via soft_validate warning pass.
 class PBase(BaseModel):
     model_config = ConfigDict(extra="ignore", protected_namespaces=(), arbitrary_types_allowed=True)
 
@@ -164,6 +166,7 @@ class ColumnMeta(PBase):
     topo_feature: Optional[Tuple[str, str, str]] = None  # Link to a geojson/topojson [url,type,col_name inside geodata]
     electoral_system: Optional[ElectoralSystem] = None  # Information about electoral system
     mandates: Optional[MandatesDict] = None  # Mandate count mapping for the electoral system
+    col_prefix: Optional[str] = None  # Prefix prepended to column names in data (from scale block)
 
     @model_serializer(mode="wrap")
     def _serialize_model(
@@ -203,13 +206,10 @@ class GroupOrColumnMeta(ColumnMeta):
     """Column metadata that can optionally describe a grouped question."""
 
     columns: Optional[List[str]] = None
-    col_prefix: Optional[str] = None
 
 
 # This is for the block-level 'scale' group - basically same as ColumnMeta but with a few extras
 class BlockScaleMeta(ColumnMeta):
-    # Only useful in 'scale' block
-    col_prefix: Optional[str] = None  # If column name should have the prefix added. Usually used in scale block
     question_colors: Dict[str, Color] = DF(dict)  # Dict mapping columns to different colors
 
 
@@ -457,6 +457,33 @@ def hard_validate(m: dict[str, object] | DataMeta) -> None:
 T = TypeVar("T", bound=BaseModel)
 
 
+def _strictify_type(ann: object) -> object:  # noqa: ANN401  # annotation types are inherently dynamic
+    """Recursively replace PBase subclasses with their strict twins inside a type annotation."""
+    if isinstance(ann, type) and issubclass(ann, PBase):
+        return _strict_model_class_cached(ann)
+
+    origin = get_origin(ann)
+    if origin is None:
+        return ann
+
+    args = get_args(ann)
+    if not args:
+        return ann
+
+    new_args = tuple(_strictify_type(a) for a in args)
+    if new_args == args:
+        return ann
+
+    if origin is Annotated:
+        # Annotated[type, *metadata] — keep metadata unchanged, replace the base type only
+        return Annotated.__class_getitem__((new_args[0],) + new_args[1:])
+
+    # Generic types: List[X], Dict[K,V], Optional[X], Union[X,Y], Tuple[X,...], etc.
+    if len(new_args) == 1:
+        return origin[new_args[0]]
+    return origin[new_args]
+
+
 def _create_strict_model_class(base_model: type[BaseModel]) -> type[BaseModel]:
     """Create a strict version of a model class with extra='forbid' for validation warnings."""
     return _strict_model_class_cached(base_model)
@@ -464,20 +491,49 @@ def _create_strict_model_class(base_model: type[BaseModel]) -> type[BaseModel]:
 
 @lru_cache(maxsize=None)
 def _strict_model_class_cached(base_model: type[BaseModel]) -> type[BaseModel]:
-    """Cached strict-model wrapper to avoid repeated dynamic class creation."""
-    # If it's already strict, don't wrap again.
-    if getattr(base_model, "model_config", None) and (
-        cast(dict[str, Any], base_model.model_config).get("extra") == "forbid"
-    ):
-        return base_model
+    """Recursively build a strict twin of base_model where every nested PBase field is also strict.
 
+    Creates a parallel strict hierarchy so that soft_validate's warning pass catches extra fields
+    at all nesting levels, not just the top level.
+    """
     if not issubclass(base_model, PBase):
         return base_model
+    if cast(dict[str, Any], base_model.model_config).get("extra") == "forbid":
+        return base_model
 
-    class StrictModel(base_model):  # type: ignore[valid-type, misc]
-        model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+    # Collect field annotations that contain PBase subclasses and need strict twins.
+    try:
+        hints = get_type_hints(base_model, include_extras=True)
+    except Exception:
+        hints = {}
 
-    return StrictModel
+    new_annotations: dict[str, Any] = {}
+    for fname in base_model.model_fields:
+        ann = hints.get(fname)
+        if ann is None:
+            continue
+        strict_ann = _strictify_type(ann)
+        if strict_ann is not ann:
+            new_annotations[fname] = strict_ann
+
+    namespace: dict[str, Any] = {
+        "model_config": ConfigDict(extra="forbid", arbitrary_types_allowed=True),
+    }
+    if new_annotations:
+        namespace["__annotations__"] = new_annotations
+        # Preserve defaults so overridden fields don't become required in the strict twin.
+        for fname in new_annotations:
+            fi = base_model.model_fields.get(fname)
+            if fi is None or fi.is_required():
+                continue
+            if fi.default_factory is not None:
+                namespace[fname] = Field(default_factory=fi.default_factory)
+            else:
+                namespace[fname] = fi.default
+
+    strict_class = type(f"Strict{base_model.__name__}", (base_model,), namespace)
+    strict_class.model_rebuild(force=True)  # type: ignore[union-attr]
+    return strict_class
 
 
 def soft_validate(
@@ -488,7 +544,9 @@ def soft_validate(
     context: dict[str, object] | None = None,
 ) -> T:
     """Validate dict/model against a pydantic model, printing warnings, then returning validated object.
-    Validates with the normal model (extra='ignore') which allows extra fields but runs all validators.
+    When warnings=True, validates against a recursively strict twin first (extra='forbid' at all levels)
+    to surface unknown keys as printed warnings, then validates with the normal model (extra='ignore')
+    which allows extra fields and runs all validators so processing can continue.
 
     Args:
         m: Dictionary or Pydantic model instance to validate.
@@ -522,8 +580,7 @@ def soft_validate(
                 msg = error["msg"]
                 print(f"  {loc}: {msg}")
 
-    # Now validate with the normal model (extra='ignore') which runs all validators
-    # and allows extra fields at all nesting levels
+    # Now validate with the normal model, which runs all validators and forbids extra fields.
     soft_context = dict(context or {})
     soft_context["validation_mode"] = "soft"
     inst = cast(T, model.model_validate(m_dict, strict=False, context=soft_context))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -24,7 +24,7 @@ from salk_toolkit.io import (
     replace_data_meta_in_parquet,
     read_parquet_metadata,
 )
-from salk_toolkit.validation import soft_validate, DataMeta, ColumnMeta, ColumnBlockMeta
+from salk_toolkit.validation import soft_validate, DataMeta, ColumnMeta
 from salk_toolkit.utils import read_json
 
 
@@ -246,18 +246,10 @@ class TestReadAnnotatedData:
         assert "structure" in meta_dict
         assert len(meta_dict["structure"]) > 0
 
-    def test_read_annotated_data_with_extra_fields(self, csv_file, meta_file, sample_csv_data):
-        """Test that read_annotated_data handles extra fields at multiple nesting levels
-
-        This test ensures that extra fields in metadata files don't cause read_annotated_data
-        to fail, which was a regression issue. Extra fields should be ignored with warnings.
-        """
+    def test_read_annotated_data_with_extra_fields(self, csv_file, meta_file, sample_csv_data, capsys):
+        """Test that read_annotated_data warns on extra fields at all nesting levels but still succeeds."""
         sample_csv_data.to_csv_file(csv_file)
 
-        # Create metadata with extra fields at multiple levels:
-        # - Top level (DataMeta)
-        # - Block level (ColumnBlockMeta)
-        # - Column metadata level (ColumnMeta)
         meta = {
             "file": "test.csv",
             "structure": [
@@ -290,28 +282,18 @@ class TestReadAnnotatedData:
         }
         write_json(meta_file, meta)
 
-        # read_annotated_data should succeed despite extra fields
-        # It should print warnings but continue processing
-        df = read_annotated_data(str(meta_file), return_raw=False)
-
-        # Verify data was loaded correctly
+        # Processing should succeed despite extra fields, with warnings printed
+        df, meta_ret = read_annotated_data(str(meta_file), return_meta=True, return_raw=False)
         assert len(df) == 5
         assert "id" in df.columns
-        assert "age" in df.columns
-        assert "name" in df.columns
-        # Verify data types are correct
-        assert df["age"].dtype in [np.int64, np.float64]  # continuous
-        assert df["name"].dtype.name == "category"  # inferred categories
-
-        # Verify metadata can be retrieved and doesn't contain extra fields
-        df_ret, meta_ret = read_annotated_data(str(meta_file), return_meta=True, return_raw=False)
         assert meta_ret is not None
-        meta_ret_dict = meta_ret.model_dump(mode="json")
-        # Extra fields should not be in returned metadata
-        assert "extra_field_1" not in meta_ret_dict
-        assert "extra_field_2" not in meta_ret_dict
-        # Valid fields should be present
-        assert meta_ret_dict.get("description") == "Valid metadata"
+        assert meta_ret.description == "Valid metadata"
+
+        # Warnings about extras should have been printed
+        captured = capsys.readouterr()
+        assert "extra_field_1" in captured.out
+        assert "extra_block_field" in captured.out
+        assert "extra_col_field" in captured.out
 
     def test_topk_create_block(self, meta_file, csv_file):
         """Test top k create block."""
@@ -2421,8 +2403,8 @@ class TestReplaceDataMetaInParquet:
 class TestSoftValidate:
     """Test soft_validate function"""
 
-    def test_soft_validate_with_extra_fields(self):
-        """Test that soft_validate returns a model even when extra fields are present at multiple nesting levels"""
+    def test_soft_validate_with_extra_fields(self, capsys):
+        """Test that soft_validate warns on extra fields at all nesting levels but returns a valid model."""
         # Create a dict with valid fields plus extra fields at multiple levels:
         # - Top level (DataMeta)
         # - Block level (ColumnBlockMeta)
@@ -2451,65 +2433,25 @@ class TestSoftValidate:
             "description": "Valid field",
         }
 
-        # soft_validate should print warnings but still return a valid DataMeta object
-        result = soft_validate(meta_dict, DataMeta)
+        result = soft_validate(meta_dict, DataMeta, warnings=True)
 
-        # Should return a DataMeta instance
+        # Should return a valid DataMeta with correct fields
         assert isinstance(result, DataMeta)
-        # Valid fields should be present
-        assert result.files is not None
-        assert len(result.files) == 1
-        assert result.files[0].file == "test.csv"
         assert result.description == "Valid field"
-        # Extra fields at top level should be ignored (not accessible as attributes)
+        assert result.files is not None and result.files[0].file == "test.csv"
+        # Extras must be silently dropped
         assert not hasattr(result, "extra_field_1")
-        assert not hasattr(result, "extra_field_2")
+        test_block = result.structure["test"]
+        assert not hasattr(test_block, "extra_block_field")
 
-        # Structure might be a list (if model_construct was used) or dict (if model_validate worked)
-        # Either way, we should be able to access the block
-        if isinstance(result.structure, dict):
-            test_block = result.structure["test"]
-            assert isinstance(test_block, ColumnBlockMeta)
-            assert test_block.name == "test"
-            # Extra field at block level should be ignored
-            assert not hasattr(test_block, "extra_block_field")
+        # Warnings about extras should have been printed
+        captured = capsys.readouterr()
+        assert "extra_field_1" in captured.out
+        assert "extra_block_field" in captured.out
+        assert "extra_col_field" in captured.out
 
-            # Verify column metadata is valid
-            # Columns is a dict mapping column names to ColumnMeta
-            assert "value" in test_block.columns
-            value_col_meta = test_block.columns["value"]
-            assert value_col_meta.source == "value" or value_col_meta.source is None
-            assert isinstance(value_col_meta, ColumnMeta)
-        else:
-            # If it's a list (from model_construct), it will be a list of dicts
-            # Find the block dict by name
-            test_block_dict = next(b for b in result.structure if isinstance(b, dict) and b.get("name") == "test")
-            assert test_block_dict["name"] == "test"
-            # Extra field at block level should be present in dict but not cause errors
-            assert "extra_block_field" in test_block_dict
-
-            # Extract column metadata from the dict structure
-            columns = test_block_dict.get("columns", [])
-            value_col_spec = next(
-                col for col in columns if (isinstance(col, list) and len(col) > 0 and col[0] == "value")
-            )
-            # Extract the ColumnMeta dict from the spec
-            if len(value_col_spec) >= 2 and isinstance(value_col_spec[-1], dict):
-                col_meta_dict = value_col_spec[-1]
-                # Create ColumnMeta from the dict to verify it works with extra fields
-                value_col_meta = ColumnMeta.model_construct(**col_meta_dict)
-            else:
-                value_col_meta = ColumnMeta()
-
-        # Verify column metadata values
-        assert isinstance(value_col_meta, ColumnMeta)
-        assert value_col_meta.categories == ["A", "B", "C"]
-        assert value_col_meta.label == "Test Value"
-        # Extra field at column level should be ignored (not accessible as attribute)
-        assert not hasattr(value_col_meta, "extra_col_field")
-
-    def test_soft_validate_with_column_meta_extra_fields(self):
-        """Test soft_validate with ColumnMeta and extra fields"""
+    def test_soft_validate_with_column_meta_extra_fields(self, capsys):
+        """Test soft_validate with ColumnMeta warns on extra fields but returns valid model."""
         col_meta_dict = {
             "categories": ["A", "B", "C"],
             "ordered": True,
@@ -2517,16 +2459,13 @@ class TestSoftValidate:
             "extra_unknown_field": "should_be_ignored",
         }
 
-        result = soft_validate(col_meta_dict, ColumnMeta)
-
-        # Should return a ColumnMeta instance
+        result = soft_validate(col_meta_dict, ColumnMeta, warnings=True)
         assert isinstance(result, ColumnMeta)
-        # Valid fields should be present
         assert result.categories == ["A", "B", "C"]
-        assert result.ordered is True
         assert result.label == "Test Column"
-        # Extra fields should be ignored
         assert not hasattr(result, "extra_unknown_field")
+        captured = capsys.readouterr()
+        assert "extra_unknown_field" in captured.out
 
     def test_soft_validate_with_already_validated_model(self):
         """Test that soft_validate returns the same instance if already a model"""
@@ -2554,7 +2493,7 @@ class TestSoftValidate:
                     # List-form column specs -> triggers BeforeValidator(_cs_lst_to_dict)
                     "columns": [
                         # invalid when categories is None (would raise in strict mode)
-                        ["x", {"ordered": True, "xyz": False}],
+                        ["x", {"ordered": True}],
                         ["y", {"categories": ["A", "B"], "ordered": False, "likert": True}],  # invalid in strict mode
                     ],
                 }

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -31,6 +31,7 @@ from utils.plot_comparison import (
     pretty_print_json_differences,
     save_plot_comparison_html,
     save_plot_matrix_comparison_html,
+    save_single_result_html,
 )
 
 # Disable Altair max rows limit for testing
@@ -151,6 +152,20 @@ class TestPlots:
             if matching_plots_dict:
                 with open(reference_matching_plots_file, "w") as f:
                     json.dump(matching_plots_dict, f, indent=2, sort_keys=True)
+            # Create HTML of result and print file:// URI (same as when comparison fails)
+            diff_dir = self.reference_dir / "diff_html"
+            diff_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                html_path = save_single_result_html(
+                    chart,
+                    result_spec,
+                    diff_dir / f"{test_name}_recomputed.html",
+                    f"{test_name} - Reference Updated",
+                )
+                if html_path is not None:
+                    print(f"Reference HTML saved to {html_path.resolve().as_uri()}")
+            except Exception as exc:  # pragma: no cover - best effort artifact
+                print(f"Failed to save reference HTML for {test_name}: {exc}")
             print(f"{'Updated' if already_exists else 'Created'} reference for test {test_name}")
             return
 
@@ -160,46 +175,14 @@ class TestPlots:
             diff_dir.mkdir(parents=True, exist_ok=True)
             plot_html_path = diff_dir / f"{test_name}_missing_reference.html"
 
-            if isinstance(chart, list):
-                # Matrix of plots - use plot_matrix_html
-                from salk_toolkit.utils import plot_matrix_html
-
-                actual_html = plot_matrix_html(chart, uid="actual", width=400, responsive=False)
-                if actual_html:
-                    # Wrap in a simple HTML page
-                    full_html = f"""<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <title>{test_name} - Missing Reference</title>
-  <style>
-    body {{ font-family: system-ui, sans-serif; margin: 24px; background: #fafafa; }}
-    h1 {{ font-size: 1.4rem; margin-bottom: 16px; color: #d00; }}
-    .plot-container {{ padding: 16px; background: #fff; border-radius: 8px; box-shadow: 0 1px 4px rgba(0,0,0,0.08); }}
-  </style>
-</head>
-<body>
-  <h1>Missing Reference - {test_name}</h1>
-  <p>Reference file not found. This is the actual plot output.</p>
-  <div class="plot-container">
-    {actual_html}
-  </div>
-</body>
-</html>"""
-                    plot_html_path.write_text(full_html, encoding="utf-8")
-            else:
-                # Single chart - use save_plot_comparison_html with dummy reference
-                # save_plot_comparison_html imported at module scope (avoid shadowing it here)
-                # Create a dummy reference spec for display (same as actual)
-                dummy_reference = result_spec.copy()
-                save_plot_comparison_html(
-                    dummy_reference,
-                    result_spec,
-                    plot_html_path,
-                    page_title=f"{test_name} - Missing Reference",
-                    reference_title="Missing Reference (showing actual only)",
-                    actual_title="Actual",
-                )
+            save_single_result_html(
+                chart,
+                result_spec,
+                plot_html_path,
+                f"Missing Reference - {test_name}",
+                subtitle="Reference file not found. This is the actual plot output.",
+                h1_color="#d00",
+            )
 
             plot_uri = plot_html_path.resolve().as_uri()
             recompute_cmd = f"pytest tests/test_plots.py::TestPlots::{test_name} --recompute"

--- a/tests/utils/plot_comparison.py
+++ b/tests/utils/plot_comparison.py
@@ -11,6 +11,32 @@ from typing import Any, Sequence
 import altair as alt
 
 Records = Sequence[dict[str, Any]] | None
+SINGLE_PLOT_HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>{page_title}</title>
+  <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
+  <style>
+    body {{ font-family: system-ui, sans-serif; margin: 24px; background: #fafafa; }}
+    h1 {{ font-size: 1.4rem; margin-bottom: 16px; }}
+    .plot-container {{ padding: 16px; background: #fff; border-radius: 8px; box-shadow: 0 1px 4px rgba(0,0,0,0.08); }}
+  </style>
+</head>
+<body>
+  <h1>{page_title}</h1>
+  <div class="plot-container">
+    <div id="plot"></div>
+  </div>
+  <script>
+    const spec = {spec};
+    vegaEmbed('#plot', spec, {{actions: false}});
+  </script>
+</body>
+</html>
+"""
 HTML_TEMPLATE = """<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -353,6 +379,77 @@ def _spec_to_dict(spec: Any) -> dict[str, Any]:
     if isinstance(spec, str):
         return json.loads(spec)
     return copy.deepcopy(spec)
+
+
+def save_single_plot_html(spec: Any, output_path: str | Path, *, page_title: str = "Plot") -> Path:
+    """Create an HTML file that renders a single plot spec."""
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    spec_dict = _spec_to_dict(spec)
+    spec_dict.pop("config", None)
+    spec_dict.setdefault("$schema", "https://vega.github.io/schema/vega-lite/v5.json")
+    html = SINGLE_PLOT_HTML_TEMPLATE.format(
+        page_title=page_title,
+        spec=json.dumps(spec_dict),
+    )
+    output.write_text(html, encoding="utf-8")
+    return output
+
+
+SINGLE_RESULT_PAGE_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>{page_title}</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; margin: 24px; background: #fafafa; }}
+    h1 {{ font-size: 1.4rem; margin-bottom: 16px; {h1_style} }}
+    .plot-container {{ padding: 16px; background: #fff; border-radius: 8px; box-shadow: 0 1px 4px rgba(0,0,0,0.08); }}
+  </style>
+</head>
+<body>
+  <h1>{page_title}</h1>
+  {subtitle}
+  <div class="plot-container">
+    {plot_html}
+  </div>
+</body>
+</html>
+"""
+
+
+def save_single_result_html(
+    chart: alt.TopLevelMixin | list,
+    result_spec: dict[str, Any],
+    output_path: str | Path,
+    page_title: str,
+    *,
+    subtitle: str | None = None,
+    h1_color: str | None = None,
+    width: int = 400,
+) -> Path | None:
+    """Save a single plot or matrix to HTML. Returns Path for single/matrix, None if matrix empty."""
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    if isinstance(chart, list):
+        from salk_toolkit.utils import plot_matrix_html
+
+        plot_html = plot_matrix_html(chart, uid="plot", width=width, responsive=False)
+        if not plot_html:
+            return None
+        sub = f"<p>{subtitle}</p>\n  " if subtitle else ""
+        h1_style = f"color: {h1_color};" if h1_color else ""
+        html = SINGLE_RESULT_PAGE_TEMPLATE.format(
+            page_title=page_title,
+            h1_style=h1_style,
+            subtitle=sub,
+            plot_html=plot_html,
+        )
+        output.write_text(html, encoding="utf-8")
+        return output
+    else:
+        return save_single_plot_html(result_spec, output, page_title=page_title)
 
 
 def save_plot_comparison_html(


### PR DESCRIPTION
Turned out the previous refactor to soft_validate only validated the topline DataMeta model w.r.t. warnings, not the entire hierarchy. AI made the behavior recursive, but looking at how it did it, I'm increasingly feeling the complexity around data metas has blown up to near unmanageable levels and it should be rebuilt to a different architecture instead of relying on pydantic magic. 

For now, however, this seems to fix the issues, and tests pass, so we live for one more day.