### PR TITLE
Support arviz 1 (pymc 6 migration)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "libsql_client",
   "matplotlib",
   "numpy",
+  "openpyxl",
   "pandas",
   "pillow",
   "polars>=1.39.0,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
   "altair",
-  "arviz",
+  "arviz>=1.1",
   "authlib",
   "frontegg",
   "hsluv",

--- a/salk_toolkit/io.py
+++ b/salk_toolkit/io.py
@@ -282,7 +282,10 @@ def _load_data_files(
                 metas.append(soft_validate(result_meta, DataMeta, warnings=True))
         elif extension in ["csv", "gz"]:
             read_opts = cast(dict[str, Any], opts) if opts else {}
-            raw_data = pd.read_csv(cast(str, mapped_file), low_memory=False, **read_opts)  # type: ignore[call-overload]
+            csv_defaults: dict[str, Any] = {"low_memory": False}
+            if read_opts.get("engine") == "python":
+                csv_defaults.pop("low_memory")  # python engine doesn't support low_memory
+            raw_data = pd.read_csv(cast(str, mapped_file), **{**csv_defaults, **read_opts})  # type: ignore[call-overload]
         elif extension in ["sav", "dta"]:
             read_fn = getattr(pyreadstat, "read_" + (mapped_file[-3:]).lower())
             with warnings.catch_warnings():  # While pyreadstat has not been updated to pandas 2.2 standards
@@ -1943,7 +1946,10 @@ def infer_meta(
         ext = os.path.splitext(fname)[1].lower()[1:]
         meta["files"] = [{"file": fname, "opts": read_opts, "code": "F0"}]
         if ext in ["csv", "gz"]:
-            df = pd.read_csv(data_file, low_memory=False, **read_opts)  # type: ignore[call-overload]
+            csv_defaults: dict[str, Any] = {"low_memory": False}
+            if read_opts.get("engine") == "python":
+                csv_defaults.pop("low_memory")  # python engine doesn't support low_memory
+            df = pd.read_csv(data_file, **{**csv_defaults, **read_opts})  # type: ignore[call-overload]
         elif ext in ["sav", "dta"]:
             read_fn = getattr(pyreadstat, "read_" + ext)
             df, sav_meta = read_fn(

--- a/salk_toolkit/plots.py
+++ b/salk_toolkit/plots.py
@@ -1379,7 +1379,7 @@ def draws_to_hdis(
     for hdiv in hdi_vals:
         ldf_v = (
             data.groupby(gbc, observed=False)[vc]
-            .apply(lambda s: pd.Series(list(az.hdi(s.to_numpy(), hdi_prob=hdiv)), index=["lo", "hi"]))
+            .apply(lambda s: pd.Series(list(az.hdi(s.to_numpy(), prob=hdiv)), index=["lo", "hi"]))
             .reset_index()
         )
         ldf_v["hdi"] = hdiv


### PR DESCRIPTION
## Summary
- Bump `arviz` pin to `>=1.1`; declare `openpyxl` as an explicit dependency (xlsx ingestion in `io.py`, previously only transitive).
- Migrate the one arviz touchpoint: `az.hdi`'s credible-mass keyword was renamed `hdi_prob` → `prob` in arviz 1.0.
- Fix `read_csv` passing the unsupported `low_memory` option with the `python` engine.

Companion to the `salk_internal_package` pymc 6 / pytensor 3 / arviz 1 migration — SIP requires this.

## Test Plan
- [x] `pytest tests/` — 217 passed, 1 skipped, under arviz 1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)