### PR TITLE
Stamp salk_toolkit git commit into parquet metadata

### DIFF
--- a/salk_toolkit/io.py
+++ b/salk_toolkit/io.py
@@ -34,9 +34,11 @@ __all__ = [
 
 import json
 import os
+import subprocess
 import warnings
 import re
 from collections import defaultdict
+from functools import lru_cache
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from copy import deepcopy
 from typing import Any, Callable, Literal, TypeAlias, TypeVar, cast, overload
@@ -1963,7 +1965,7 @@ def infer_meta(
             if translate_fn:
                 col_labels = {k: translate_fn(v) for k, v in col_labels.items()}
         elif ext == "parquet":
-            df = pd.read_parquet(data_file, **read_opts)
+            df = pd.read_parquet(data_file, **read_opts)  # type: ignore[call-overload]
         elif ext in ["xls", "xlsx", "xlsm", "xlsb", "odf", "ods", "odt"]:
             df = pd.read_excel(data_file, **read_opts)  # type: ignore[call-overload]
         else:
@@ -2280,6 +2282,23 @@ def _find_type_in_dict(d: object, dtype: type, path: str = "") -> None:
 custom_meta_key = "salk-toolkit-meta"
 
 
+@lru_cache(maxsize=1)
+def get_stk_commit() -> str | None:
+    """Short git commit of the salk_toolkit checkout, or None when not running from a git repo."""
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "rev-parse", "--short", "HEAD"],
+                cwd=os.path.dirname(os.path.abspath(__file__)),
+                stderr=subprocess.DEVNULL,
+                text=True,
+            ).strip()
+            or None
+        )
+    except Exception:
+        return None
+
+
 def write_parquet_with_metadata(df: pd.DataFrame, meta: dict[str, object] | ParquetMeta, file_name: str) -> None:
     """Write DataFrame to Parquet file with embedded metadata.
 
@@ -2298,6 +2317,12 @@ def write_parquet_with_metadata(df: pd.DataFrame, meta: dict[str, object] | Parq
     data_meta = meta_payload.get("data")
     if isinstance(data_meta, DataMeta):
         meta_payload["data"] = data_meta.model_dump(mode="json")
+
+    # Stamp the writing salk_toolkit commit so files are self-describing; callers may override.
+    if not meta_payload.get("stk_commit"):
+        stk_commit = get_stk_commit()
+        if stk_commit:
+            meta_payload["stk_commit"] = stk_commit
 
     custom_meta_json = json.dumps(meta_payload)
     existing_meta = table.schema.metadata

--- a/salk_toolkit/validation.py
+++ b/salk_toolkit/validation.py
@@ -599,6 +599,8 @@ class ParquetMeta(BaseModel):
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
     data: DataMeta
+    stk_commit: Optional[str] = None  # salk_toolkit git commit that wrote the file
+    sip_commit: Optional[str] = None  # salk_internal_package git commit (set by run_stack)
 
 
 DataSpec = Union[str, "DataDescription"]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2785,6 +2785,50 @@ class TestReplaceDataMetaInParquet:
         assert group_cols == {"test_group": ["renamed_col", "keep_same", "response", "party"]}
 
 
+class TestParquetCommitStamps:
+    """write_parquet_with_metadata stamps the salk_toolkit commit into the metadata"""
+
+    def test_stk_commit_stamped_and_read_back(self, temp_dir):
+        """Written parquet carries the current salk_toolkit git commit; sip_commit stays unset."""
+        import subprocess
+        import os
+        import salk_toolkit.io as stk_io
+
+        df = pd.DataFrame({"a": [1, 2, 3]})
+        meta = {"data": {"structure": [{"name": "blk", "columns": ["a"]}]}}
+        path = os.path.join(temp_dir, "stamped.parquet")
+        write_parquet_with_metadata(df, meta, path)
+
+        expected = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=os.path.dirname(os.path.abspath(stk_io.__file__)),
+            text=True,
+        ).strip()
+
+        pmeta = read_parquet_metadata(path)
+        assert pmeta is not None
+        assert pmeta.stk_commit == expected
+        assert pmeta.sip_commit is None
+
+    def test_explicit_commits_preserved(self, temp_dir):
+        """Caller-provided stk_commit/sip_commit values are not overwritten by the auto-stamp."""
+        import os
+
+        df = pd.DataFrame({"a": [1]})
+        meta = {
+            "data": {"structure": [{"name": "blk", "columns": ["a"]}]},
+            "stk_commit": "cafe123",
+            "sip_commit": "beef456",
+        }
+        path = os.path.join(temp_dir, "explicit.parquet")
+        write_parquet_with_metadata(df, meta, path)
+
+        pmeta = read_parquet_metadata(path)
+        assert pmeta is not None
+        assert pmeta.stk_commit == "cafe123"
+        assert pmeta.sip_commit == "beef456"
+
+
 class TestSoftValidate:
     """Test soft_validate function"""
 


### PR DESCRIPTION
## What

- `write_parquet_with_metadata` now stamps the writing salk_toolkit **git commit** into the embedded parquet metadata (`stk_commit`), unless the caller already provided one.
- `ParquetMeta` gains first-class optional `stk_commit` / `sip_commit` fields (previously only reachable via `extra="allow"`).
- New cached helper `get_stk_commit()` — returns the short hash of the salk_toolkit checkout, or `None` for non-git installs (no stamp, no error).

## Why

Modelrun parquets uploaded to DMS require `stk_commit`/`sip_commit`, typed by hand today. With the commit embedded at write time, DMS can read it from the file itself (companion PRs in salk_internal_package fill `sip_commit`, and in dms drop the required form fields).

## Notes

- Caller-provided values are never overwritten, so replaying/repairing metadata stays possible.
- Drive-by: silenced a pre-existing pyright overload false-positive on `pd.read_parquet` (`io.py`) that was failing the pre-commit hook on main — same ignore idiom as the excel branch two lines below.

## Tests

- `TestParquetCommitStamps` — stamp round-trips through `read_parquet_metadata` and matches `git rev-parse --short HEAD`; explicit values preserved.
- Full suite: 219 passed, 1 skipped; ruff and pyright hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)