### PR TITLE
Refactor the io pipeline internals (cleanup)

### DIFF
--- a/salk_toolkit/io/__init__.py
+++ b/salk_toolkit/io/__init__.py
@@ -31,14 +31,10 @@ __all__ = [
     "update_meta_with_model_fields",
 ]
 
-from salk_toolkit.io.core import (  # noqa: F401
-    _convert_datetime_series_to_categorical,
-    _convert_number_series_to_categorical,
-)
+from salk_toolkit.io.core import Dataset, HookEnv, ProcessOpts, SourceBundle  # noqa: F401
 from salk_toolkit.io.datasets import infer_meta, read_and_process_data, read_annotated_data
 from salk_toolkit.io.meta import (
     _fix_meta_categories,  # noqa: F401  # imported from here by salk_internal_package.sampling.meta
-    _get_original_column_names,  # noqa: F401  # imported from here by tests
     extract_column_meta,
     fix_df_with_meta,  # noqa: F401  # imported from here by dashboard
     group_columns_dict,
@@ -46,6 +42,7 @@ from salk_toolkit.io.meta import (
     update_meta_with_model_fields,
 )
 from salk_toolkit.io.parquet import (
+    get_stk_commit,  # noqa: F401
     read_parquet_metadata,
     read_parquet_with_metadata,
     replace_data_meta_in_parquet,

--- a/salk_toolkit/io/core.py
+++ b/salk_toolkit/io/core.py
@@ -1,11 +1,15 @@
-"""Core helpers shared across the io package: shared series converters and the processed-data alias."""
+"""Core types shared across the io package: the Dataset/SourceBundle value objects,
+processing options, the hook execution environment, and shared series helpers."""
 
-import warnings
-from typing import TypeAlias
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import NamedTuple, cast
 
 import numpy as np
 import pandas as pd
+import scipy as sp
 
+import salk_toolkit as stk
 from salk_toolkit.utils import (
     is_date_str_series,
     is_numeric_str_series,
@@ -15,9 +19,6 @@ from salk_toolkit.validation import (
 )
 
 
-warnings.filterwarnings("ignore", "DataFrame is highly fragmented.*", pd.errors.PerformanceWarning)
-
-
 def _str_from_list(val: list[str] | object) -> str:
     """Convert a list to a newline-separated string, or return string representation."""
     if isinstance(val, list):
@@ -25,7 +26,76 @@ def _str_from_list(val: list[str] | object) -> str:
     return str(val)
 
 
-ProcessedDataReturn: TypeAlias = tuple[pd.DataFrame, DataMeta | None]
+class Dataset(NamedTuple):
+    """A processed dataframe together with its (possibly absent) metadata."""
+
+    df: pd.DataFrame
+    meta: DataMeta | None
+
+
+@dataclass
+class SourceBundle:
+    """Per-file frames of one data source, before concatenation."""
+
+    frames: dict[str, pd.DataFrame]  # keyed by file_code, insertion-ordered
+    env: dict[str, object] = field(default_factory=dict)  # reader metadata (e.g. sav labels), visible to hooks
+    meta: DataMeta | None = None  # meta carried by annotated sources
+
+    def ranges(self) -> dict[str, slice]:
+        """Row range of each file in the concatenated frame."""
+        out, start = {}, 0
+        for fc, fdf in self.frames.items():
+            out[fc] = slice(start, start + len(fdf))
+            start += len(fdf)
+        return out
+
+    def concat(self, reset_index: bool = False) -> pd.DataFrame:
+        """Concatenate the per-file frames in file order."""
+        if not self.frames:
+            return pd.DataFrame()
+        cdf = pd.concat(self.frames.values())
+        return cdf.reset_index(drop=True) if reset_index else cdf
+
+
+@dataclass(frozen=True)
+class ProcessOpts:
+    """Processing options that travel with the (possibly recursive) load."""
+
+    ignore_exclusions: bool = False  # Keep rows listed in meta `excluded`
+    add_original_inds: bool = False  # Keep the `original_inds` column in the result
+
+
+class HookEnv:
+    """Uniform execution environment for user code embedded in metafiles.
+
+    exec hooks (preprocessing/postprocessing) see pd/np/sp/stk + reader env + constants;
+    eval expressions (transform/subgroup_transform) see pd/np/stk + constants,
+    matching the historical hook namespaces exactly.
+    """
+
+    def __init__(self, env: Mapping[str, object] | None = None, constants: Mapping[str, object] | None = None) -> None:
+        """Capture the reader metadata and meta constants that hooks may reference."""
+        self.env = dict(env or {})
+        self.constants = dict(constants or {})
+
+    def exec_df(self, code: str | list[str], df: pd.DataFrame, **extra: object) -> pd.DataFrame:
+        """Run an exec hook with `df` in scope and return the resulting `df`."""
+        globs: dict[str, object] = {
+            "pd": pd,
+            "np": np,
+            "sp": sp,
+            "stk": stk,
+            "df": df,
+            **extra,
+            **self.env,
+            **self.constants,
+        }
+        exec(_str_from_list(code), globs)
+        return cast(pd.DataFrame, globs["df"])
+
+    def eval(self, expr: str, **names: object) -> object:
+        """Evaluate a transform expression with the given names in scope."""
+        return eval(expr, {**names, "pd": pd, "np": np, "stk": stk, **self.constants})
 
 
 def _convert_number_series_to_categorical(s: pd.Series) -> pd.Series:

--- a/salk_toolkit/io/create_blocks.py
+++ b/salk_toolkit/io/create_blocks.py
@@ -469,7 +469,6 @@ def _create_topk_metas_and_dfs_list(
 
 CreateBlockModel = TopKBlock | MaxDiffBlock
 
-
 create_block_type_to_create_fn: dict[str, Callable] = {
     "topk": _create_topk_metas_and_dfs,  # type: ignore[assignment]
     "maxdiff": _create_maxdiff_metas_and_dfs,  # type: ignore[assignment]

--- a/salk_toolkit/io/datasets.py
+++ b/salk_toolkit/io/datasets.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, Literal, cast, overload
 
 import numpy as np
 import pandas as pd
-import pyreadstat  # type: ignore[import-untyped]
 import scipy as sp
 
 import salk_toolkit as stk
@@ -26,28 +25,44 @@ from salk_toolkit.validation import (
     soft_validate,
 )
 
-from salk_toolkit.io.core import ProcessedDataReturn, _str_from_list
-from salk_toolkit.io.meta import _fix_meta_categories, _is_categorical, fix_df_with_meta
-from salk_toolkit.io.parquet import read_parquet_with_metadata
-from salk_toolkit.io.pipeline import _process_annotated_data
-from salk_toolkit.io.sources import _load_data_files
+from salk_toolkit.io import readers
+from salk_toolkit.io.core import Dataset, ProcessOpts, _str_from_list
+from salk_toolkit.io.meta import _is_categorical, fix_df_with_meta
+from salk_toolkit.io.sources import _load_data_files, _load_dataset, _process_annotated_data
 
 
 @overload
 def read_annotated_data(
-    fname: str, infer: bool = ..., return_raw: bool = ..., *, return_meta: Literal[True], **kwargs: object
-) -> ProcessedDataReturn: ...
+    fname: str,
+    infer: bool = ...,
+    return_raw: bool = ...,
+    *,
+    return_meta: Literal[True],
+    ignore_exclusions: bool = ...,
+    add_original_inds: bool = ...,
+) -> Dataset: ...
 
 
 @overload
 def read_annotated_data(
-    fname: str, infer: bool = ..., return_raw: bool = ..., *, return_meta: Literal[False] = False, **kwargs: object
+    fname: str,
+    infer: bool = ...,
+    return_raw: bool = ...,
+    return_meta: Literal[False] = False,
+    *,
+    ignore_exclusions: bool = ...,
+    add_original_inds: bool = ...,
 ) -> pd.DataFrame: ...
 
 
 def read_annotated_data(
-    fname: str, infer: bool = True, return_raw: bool = False, return_meta: bool = False, **kwargs: object
-) -> pd.DataFrame | ProcessedDataReturn:
+    fname: str,
+    infer: bool = True,
+    return_raw: bool = False,
+    return_meta: bool = False,
+    ignore_exclusions: bool = False,
+    add_original_inds: bool = False,
+) -> pd.DataFrame | Dataset:
     """Read either a json annotation and process the data, or a processed parquet with the annotation attached.
 
     Args:
@@ -56,7 +71,8 @@ def read_annotated_data(
         return_raw: Whether to return raw unprocessed data (for debugging).
             Return_raw is here for easier debugging of metafiles and is not meant to be used in production.
         return_meta: Whether to return metadata along with data.
-        **kwargs: Additional arguments passed to processing functions.
+        ignore_exclusions: Whether to keep rows listed in meta `excluded`.
+        add_original_inds: Whether to keep the `original_inds` column in the result.
 
     Returns:
         DataFrame, or tuple of (DataFrame, metadata) if return_meta=True.
@@ -64,59 +80,21 @@ def read_annotated_data(
     _, ext = os.path.splitext(fname)
     data: pd.DataFrame | None = None
     meta_obj: DataMeta | None = None
-    if ext in {".json", ".yaml"}:
-        # Extract parameters from kwargs that are valid for _process_annotated_data
-        ignore_exclusions = bool(kwargs.get("ignore_exclusions", False))
-        only_fix_categories = bool(kwargs.get("only_fix_categories", False))
-        add_original_inds = bool(kwargs.get("add_original_inds", False))
-        # Pass all parameters explicitly to match overloads - return_meta=True means ProcessedDataReturn
-        data, meta_obj = _process_annotated_data(
-            meta_fname=fname,
-            return_meta=True,
-            return_raw=return_raw,
-            ignore_exclusions=ignore_exclusions,
-            only_fix_categories=only_fix_categories,
-            add_original_inds=add_original_inds,
-        )
-    elif ext == ".parquet":
-        data, full_meta = read_parquet_with_metadata(fname)
-        if full_meta is not None:
-            meta_obj = full_meta.data
+    opts = ProcessOpts(ignore_exclusions=ignore_exclusions, add_original_inds=add_original_inds)
+    if return_raw and ext in {".json", ".yaml"}:  # Concatenated raw source data, for debugging metafiles
+        data, meta_obj = _process_annotated_data(meta_fname=fname, opts=opts, return_raw=True)
+    elif ext in {".json", ".yaml", ".parquet"}:
+        data, meta_obj = _load_dataset(fname, opts)
 
-    if meta_obj is not None or not infer:
-        assert isinstance(data, pd.DataFrame), "Expected data to be DataFrame"
-        if return_meta:
-            return (data, meta_obj)
-        return data
+    if meta_obj is None and infer:
+        warn(f"Warning: using inferred meta for {fname}")
+        inferred_meta = infer_meta(fname, meta_file=False)
+        data, meta_obj = _process_annotated_data(data_file=fname, meta=inferred_meta, opts=opts, return_raw=return_raw)
 
-    warn(f"Warning: using inferred meta for {fname}")
-    inferred_meta = infer_meta(fname, meta_file=False)
-    # Extract parameters from kwargs that are valid for _process_annotated_data
-    ignore_exclusions = bool(kwargs.get("ignore_exclusions", False))
-    only_fix_categories = bool(kwargs.get("only_fix_categories", False))
-    add_original_inds = bool(kwargs.get("add_original_inds", False))
-    # Use conditional to match overloads based on return_meta value
-    # Pass return_meta first (after *) to help Pyright match overloads
+    assert isinstance(data, pd.DataFrame), "Expected data to be DataFrame"
     if return_meta:
-        return _process_annotated_data(
-            data_file=fname,
-            meta=inferred_meta,
-            return_meta=True,
-            return_raw=return_raw,
-            ignore_exclusions=ignore_exclusions,
-            only_fix_categories=only_fix_categories,
-            add_original_inds=add_original_inds,
-        )
-    else:
-        return _process_annotated_data(
-            data_file=fname,
-            meta=inferred_meta,
-            return_meta=False,
-            return_raw=return_raw,
-            ignore_exclusions=ignore_exclusions,
-            only_fix_categories=only_fix_categories,
-            add_original_inds=add_original_inds,
-        )
+        return Dataset(data, meta_obj)
+    return data
 
 
 max_cats = 50
@@ -198,27 +176,14 @@ def infer_meta(
         path, fname = os.path.split(data_file)
         ext = os.path.splitext(fname)[1].lower()[1:]
         meta["files"] = [{"file": fname, "opts": read_opts, "code": "F0"}]
-        if ext in ["csv", "gz"]:
-            csv_defaults: dict[str, Any] = {"low_memory": False}
-            if read_opts.get("engine") == "python":
-                csv_defaults.pop("low_memory")  # python engine doesn't support low_memory
-            df = pd.read_csv(data_file, **{**csv_defaults, **read_opts})  # type: ignore[call-overload]
-        elif ext in ["sav", "dta"]:
-            read_fn = getattr(pyreadstat, "read_" + ext)
-            df, sav_meta = read_fn(
-                data_file,
-                **{"apply_value_formats": True, "dates_as_pandas_datetime": True},
-                **read_opts,
-            )
-            col_labels = dict(
-                zip(sav_meta.column_names, sav_meta.column_labels)
-            )  # Make this data easy to access by putting it in meta as constant
-            if translate_fn:
-                col_labels = {k: translate_fn(v) for k, v in col_labels.items()}
-        elif ext == "parquet":
+        if ext == "parquet":
             df = pd.read_parquet(data_file, **read_opts)  # type: ignore[call-overload]
-        elif ext in ["xls", "xlsx", "xlsm", "xlsb", "odf", "ods", "odt"]:
-            df = pd.read_excel(data_file, **read_opts)  # type: ignore[call-overload]
+        elif ext in readers._TABULAR_EXTENSIONS:
+            df, fenv = readers._read_tabular(data_file, ext, cast(dict[str, Any], dict(read_opts)))
+            if fenv:  # sav/dta reader metadata: expose column labels for easy access as a constant
+                col_labels = dict(zip(cast(list[str], fenv["column_names"]), cast(list[str], fenv["column_labels"])))
+                if translate_fn:
+                    col_labels = {k: translate_fn(v) for k, v in col_labels.items()}
         else:
             raise Exception(f"Not a known file format {data_file}")
 
@@ -328,7 +293,7 @@ def infer_meta(
 def _data_with_inferred_meta(data_file: str, **kwargs: object) -> tuple[pd.DataFrame, DataMeta]:
     """Read data file and infer metadata if not present."""
     meta = infer_meta(data_file, meta_file=False, **kwargs)
-    df, meta_result = _process_annotated_data(meta=meta, data_file=data_file, return_meta=True)  # type: ignore[call-overload]
+    df, meta_result = _process_annotated_data(meta=meta, data_file=data_file)
     assert meta_result is not None, "Expected metadata to be present"
     return df, meta_result
 
@@ -404,7 +369,9 @@ def read_and_process_data(
     return_meta: Literal[False] = False,
     constants: Mapping[str, JSONValue] | None = ...,
     skip_postprocessing: bool = ...,
-    **kwargs: object,
+    *,
+    ignore_exclusions: bool = ...,
+    add_original_inds: bool = ...,
 ) -> pd.DataFrame: ...
 
 
@@ -414,7 +381,9 @@ def read_and_process_data(
     return_meta: Literal[True],
     constants: Mapping[str, JSONValue] | None = ...,
     skip_postprocessing: bool = ...,
-    **kwargs: object,
+    *,
+    ignore_exclusions: bool = ...,
+    add_original_inds: bool = ...,
 ) -> tuple[pd.DataFrame, DataMeta]: ...
 
 
@@ -423,7 +392,8 @@ def read_and_process_data(
     return_meta: bool = False,
     constants: Mapping[str, JSONValue] | None = None,
     skip_postprocessing: bool = False,
-    **kwargs: Any,
+    ignore_exclusions: bool = False,
+    add_original_inds: bool = False,
 ) -> pd.DataFrame | tuple[pd.DataFrame, DataMeta]:
     """Read and process data according to a description object.
 
@@ -432,7 +402,8 @@ def read_and_process_data(
         return_meta: Whether to return metadata along with data.
         constants: Dictionary of constants for preprocessing/postprocessing.
         skip_postprocessing: Whether to skip postprocessing step.
-        **kwargs: Additional arguments passed to file readers.
+        ignore_exclusions: Whether to keep rows listed in meta `excluded`.
+        add_original_inds: Whether to keep the `original_inds` column in the result.
 
     Returns:
         DataFrame, or tuple of (DataFrame, metadata) if return_meta=True.
@@ -453,11 +424,6 @@ def read_and_process_data(
     if isinstance(desc_obj, DataDescription) and desc_obj.data is not None:
         df, meta_obj, einfo = pd.DataFrame(data=desc_obj.data), None, {}
     else:
-        # Extract parameters from kwargs
-        ignore_exclusions = kwargs.get("ignore_exclusions", False)
-        only_fix_categories = kwargs.get("only_fix_categories", False)
-        add_original_inds = kwargs.get("add_original_inds", False)
-
         # Get files list from description
         if isinstance(desc_obj, DataDescription) and desc_obj.files:
             files_list = desc_obj.files
@@ -465,33 +431,23 @@ def read_and_process_data(
             raise ValueError("No files provided in DataDescription")
 
         # Load files directly
-        raw_data_dict, meta_raw, einfo = _load_data_files(
+        bundle = _load_data_files(
             files_list,
             path=None,
             read_opts={},
-            ignore_exclusions=ignore_exclusions,
-            only_fix_categories=only_fix_categories,
-            add_original_inds=add_original_inds,
+            opts=ProcessOpts(ignore_exclusions=ignore_exclusions, add_original_inds=add_original_inds),
         )
-
-        # Concatenate for backward compatibility
-        df = pd.concat(raw_data_dict.values())
-        if meta_raw is None:
-            meta_obj = None
-        elif isinstance(meta_raw, DataMeta):
-            meta_obj = meta_raw
-        else:
-            meta_obj = soft_validate(meta_raw, DataMeta, warnings=True)
-
-        # Ensure returned metadata categories reflect reconciled categoricals (including injected extra fields).
-        if meta_obj is not None:
-            meta_obj = _fix_meta_categories(meta_obj, df, warnings=False)
+        # Meta categories already reflect reconciled categoricals (incl. injected extra
+        # fields): _load_data_files runs _fix_meta_categories on the same frames.
+        df, meta_obj, einfo = bundle.concat(), bundle.meta, bundle.env
 
     if meta_obj is None and return_meta:
         raise Exception("No meta found on any of the files")
 
     # Perform transformation and filtering (only for DataDescription)
     if isinstance(desc_obj, DataDescription):
+        # One shared exec/eval namespace on purpose (unlike the per-hook HookEnv in the pipeline):
+        # names defined by preprocessing code stay visible to filter and postprocessing.
         globs = {"pd": pd, "np": np, "sp": sp, "stk": stk, "df": df, **einfo, **constants}
         if desc_obj.preprocessing:
             exec(_str_from_list(desc_obj.preprocessing), globs)
@@ -500,11 +456,7 @@ def read_and_process_data(
             globs["df"] = globs["df"][eval(desc_obj.filter, globs)]
         if desc_obj.merge:
             # Note: expects merge files to have corresponding meta in global DataMeta file
-            oldcols = globs["df"].columns
             globs["df"] = _perform_merges(globs["df"], desc_obj.merge, constants, meta_obj)
-            if kwargs.get("data_meta", False):
-                newcols = [col for col in globs["df"].columns if col not in oldcols]
-                globs["df"].loc[:, newcols] = fix_df_with_meta(globs["df"][newcols], kwargs["data_meta"])
         if desc_obj.postprocessing and not skip_postprocessing:
             exec(_str_from_list(desc_obj.postprocessing), globs)
         df = globs["df"]
@@ -513,16 +465,3 @@ def read_and_process_data(
         assert meta_obj is not None, "Meta should not be None when return_meta=True"
         return df, meta_obj
     return df
-
-
-def _find_type_in_dict(d: object, dtype: type, path: str = "") -> None:
-    """Find values of a specific type in a nested dictionary to debug non-serializable JSONs."""
-    print(d, path)
-    if isinstance(d, dict):
-        for k, v in d.items():
-            _find_type_in_dict(v, dtype, path + f"{k}:")
-    if isinstance(d, list):
-        for i, v in enumerate(d):
-            _find_type_in_dict(v, dtype, path + f"[{i}]")
-    elif isinstance(d, dtype):
-        raise Exception(f"Value {d} of type {dtype} found at {path}")

--- a/salk_toolkit/io/meta.py
+++ b/salk_toolkit/io/meta.py
@@ -1,4 +1,4 @@
-"""Metadata introspection, category reconciliation and dtype-fixing for DataMeta structures."""
+"""Metadata introspection and reconciliation helpers for DataMeta structures."""
 
 from collections.abc import Sequence
 from typing import TypeVar
@@ -50,6 +50,9 @@ def fix_df_with_meta(df: pd.DataFrame, dmeta: DataMeta) -> pd.DataFrame:
     return df
 
 
+# Helper functions designed to be used with the annotations
+
+
 def extract_column_meta(data_meta: DataMeta) -> dict[str, GroupOrColumnMeta]:
     """Convert data_meta into a dict where each group and column maps to their metadata dict."""
 
@@ -87,6 +90,10 @@ def extract_column_meta(data_meta: DataMeta) -> dict[str, GroupOrColumnMeta]:
     return res
 
 
+# Convert data_meta into a dict of group_name -> [column names]
+# TODO: deprecate - info available in extract_column_meta
+
+
 def group_columns_dict(data_meta: DataMeta) -> dict[str, list[str]]:
     """Get dictionary mapping group names to their column lists."""
 
@@ -101,6 +108,8 @@ def group_columns_dict(data_meta: DataMeta) -> dict[str, list[str]]:
         prefix = scale_meta.col_prefix if scale_meta is not None and scale_meta.col_prefix is not None else ""
         res[block.name] = [f"{prefix}{cn}" for cn in block.columns.keys()]
     return res
+
+    # return { g['name'] : [(t[0] if type(t)!=str else t) for t in g['columns']] for g in data_meta['structure'] }
 
 
 T_list_alias = TypeVar("T_list_alias")

--- a/salk_toolkit/io/parquet.py
+++ b/salk_toolkit/io/parquet.py
@@ -72,6 +72,21 @@ def _fix_parquet_categories(parquet_name: str) -> None:
     write_parquet_with_metadata(df, meta, parquet_name)
 
 
+def _find_type_in_dict(d: object, dtype: type, path: str = "") -> None:
+    """Find values of a specific type in a nested dictionary to debug non-serializable JSONs."""
+    print(d, path)
+    if isinstance(d, dict):
+        for k, v in d.items():
+            _find_type_in_dict(v, dtype, path + f"{k}:")
+    if isinstance(d, list):
+        for i, v in enumerate(d):
+            _find_type_in_dict(v, dtype, path + f"[{i}]")
+    elif isinstance(d, dtype):
+        raise Exception(f"Value {d} of type {dtype} found at {path}")
+
+
+# These two very helpful functions are borrowed from https://towardsdatascience.com/saving-metadata-with-dataframes-71f51f558d8e
+
 custom_meta_key = "salk-toolkit-meta"
 
 

--- a/salk_toolkit/io/pipeline.py
+++ b/salk_toolkit/io/pipeline.py
@@ -1,36 +1,28 @@
-"""The annotation pipeline: _process_annotated_data turns loaded source files into a processed dataframe + meta."""
+"""The annotation pipeline: stages that turn a SourceBundle + DataMeta into a processed Dataset."""
 
-import os
-from typing import Literal, cast, overload
+from typing import cast
 
 import numpy as np
 import pandas as pd
-import scipy as sp
 
-import salk_toolkit as stk
-from salk_toolkit.utils import (
-    read_json,
-    read_yaml,
-    warn,
-)
+from salk_toolkit.utils import warn
 from salk_toolkit.validation import (
     ColumnBlockMeta,
     ColumnMeta,
     DataMeta,
-    FileDesc,
     soft_validate,
 )
 
-from salk_toolkit.io import readers
 from salk_toolkit.io.core import (
-    ProcessedDataReturn,
+    Dataset,
+    HookEnv,
+    ProcessOpts,
+    SourceBundle,
     _deterministic_categories_and_values,
     _is_series_of_lists,
-    _str_from_list,
 )
 from salk_toolkit.io.create_blocks import _create_new_columns_and_metas
 from salk_toolkit.io.meta import _fix_meta_categories
-from salk_toolkit.io.sources import _load_data_files
 
 
 def _file_meta_map(dfs: dict[str, pd.DataFrame]) -> dict[str, str]:
@@ -45,151 +37,26 @@ def _file_meta_map(dfs: dict[str, pd.DataFrame]) -> dict[str, str]:
     return dict(zip(fm["file_code"], fm["file_name"]))
 
 
-@overload
-def _process_annotated_data(
-    meta_fname: str | None = ...,
-    meta: DataMeta | dict[str, object] | None = ...,
-    data_file: str | None = ...,
-    raw_data: pd.DataFrame | None = ...,
-    *,
-    return_meta: Literal[True],
-    ignore_exclusions: bool = ...,
-    only_fix_categories: bool = ...,
-    return_raw: bool = ...,
-    add_original_inds: bool = ...,
-) -> ProcessedDataReturn: ...
+def _inject_files_block(bundle: SourceBundle, meta_obj: DataMeta, file_names: dict[str, str]) -> DataMeta:
+    """(Re)stamp provenance columns and add the generated `files` block to the structure.
 
+    The columns are overwritten to guarantee correctness even if preprocessing mutated/dropped them.
+    The block gets explicit ordered categories (no "infer") for determinism, so the system file
+    columns can be used downstream (e.g. plotting/pipeline).
+    """
+    for fc, fdf in bundle.frames.items():
+        fdf["file_code"] = str(fc)
+        fdf["file_name"] = file_names[fc]
 
-@overload
-def _process_annotated_data(
-    meta_fname: str | None = ...,
-    meta: DataMeta | dict[str, object] | None = ...,
-    data_file: str | None = ...,
-    raw_data: pd.DataFrame | None = ...,
-    return_meta: Literal[False] = False,
-    ignore_exclusions: bool = ...,
-    only_fix_categories: bool = ...,
-    return_raw: bool = ...,
-    add_original_inds: bool = ...,
-) -> pd.DataFrame: ...
-
-
-def _process_annotated_data(
-    meta_fname: str | None = None,
-    meta: DataMeta | dict[str, object] | None = None,
-    data_file: str | None = None,
-    raw_data: pd.DataFrame | dict[str, pd.DataFrame] | None = None,
-    return_meta: bool = False,
-    ignore_exclusions: bool = False,
-    only_fix_categories: bool = False,
-    return_raw: bool = False,
-    add_original_inds: bool = False,
-) -> pd.DataFrame | ProcessedDataReturn:
-    """Process annotated data according to metadata specifications."""
-    # Read metafile
-    metafile = cast(dict[str, str], readers.stk_file_map).get(meta_fname, meta_fname)  # type: ignore[call-overload]
-    meta_input: DataMeta | dict[str, object] | None = meta
-    if meta_fname is not None:
-        ext = os.path.splitext(metafile)[1]
-        if ext == ".yaml":
-            meta_raw = read_yaml(metafile)
-        elif ext == ".json":
-            meta_raw = read_json(metafile)
-        else:
-            raise Exception(f"Unknown meta file format {ext} for file: {meta_fname}")
-        assert isinstance(meta_raw, dict), "Meta file must contain a dict"
-        meta_input = dict(meta_raw)  # Cast to ensure object values
-
-    # Soft-validate and work with Pydantic DataMeta object throughout
-    if meta_input is None:
-        raise ValueError("Metadata cannot be None")
-    meta_obj = soft_validate(meta_input, DataMeta, warnings=True)
-    constants: dict[str, object] = dict(meta_obj.constants)
-    # Now meta is guaranteed to be a DataMeta object, not None
-
-    # Read datafile(s) - now returns dict[str, pd.DataFrame] for per-file processing
-    # Handle data_file override or ensure files list is populated
-    raw_data_dict: dict[str, pd.DataFrame] | None = None
-    if raw_data is None:
-        if data_file is not None:
-            # data_file override: use it directly
-            files_list = [FileDesc(file=data_file, opts=meta_obj.read_opts)]
-        elif meta_obj.files is not None:
-            files_list = meta_obj.files
-        else:
-            raise ValueError("No files provided in metadata")
-
-        raw_data_dict, inp_meta, einfo = _load_data_files(
-            files_list,
-            path=meta_fname if meta_fname is not None else (data_file if data_file is not None else None),
-            read_opts=meta_obj.read_opts,
-            ignore_exclusions=ignore_exclusions,
-            only_fix_categories=only_fix_categories,
-            add_original_inds=add_original_inds,
-        )
-        if inp_meta is not None:
-            warn("Processing main meta file")  # Print this to separate warnings for input jsons from main
-    elif isinstance(raw_data, dict):
-        raw_data_dict = raw_data
-        einfo = {}
-    else:
-        # Backward compatibility: single DataFrame -> treat as single-file dict
-        raw_data_dict = {"F0": raw_data}
-        einfo = {}
-
-    if return_raw:
-        # Return concatenated for backward compatibility
-        raw_data_concat = pd.concat(raw_data_dict.values()) if raw_data_dict else pd.DataFrame()
-        if return_meta:
-            return (raw_data_concat, meta_obj)
-        return raw_data_concat
-
-    assert raw_data_dict is not None, "Expected raw_data_dict to be initialized before processing"
-
-    file_meta_map = _file_meta_map(raw_data_dict)
-    file_codes_in_order = list(raw_data_dict.keys())
-    raw_data_dict = {fc: raw_data_dict[fc] for fc in file_codes_in_order}
-
-    # Run preprocessing per file
-    if meta_obj.preprocessing is not None and not only_fix_categories:
-        for file_code, df in raw_data_dict.items():
-            file_name = file_meta_map[file_code]
-            globs = {
-                "pd": pd,
-                "np": np,
-                "sp": sp,
-                "stk": stk,
-                "df": df,
-                "file_code": file_code,
-                "file_name": file_name,
-                **einfo,
-                **constants,
-            }
-            exec(_str_from_list(meta_obj.preprocessing), globs)
-            raw_data_dict[file_code] = globs["df"]
-
-    # Ensure file metadata columns always survive end-to-end (also if preprocessing dropped/mutated them).
-    file_names_in_order: list[str] = []
-    for file_code in file_codes_in_order:
-        df = raw_data_dict[file_code]
-        file_name_val = file_meta_map[file_code]
-        # Overwrite to guarantee correctness even if preprocessing mutated/dropped these columns.
-        df["file_code"] = str(file_code)
-        df["file_name"] = file_name_val
-        raw_data_dict[file_code] = df
-        file_names_in_order.append(file_name_val)
-
-    # Inject implicit metadata for system file columns so they can be used downstream (e.g. plotting/pipeline).
-    # Provide explicit ordered category order (no "infer") for determinism.
     sys_block_name = "files"
-    sys_block_hidden = len(raw_data_dict) <= 1
+    sys_block_hidden = len(bundle.frames) <= 1
     sys_block_dict: dict[str, object] = {
         "name": sys_block_name,
         "generated": True,
         "hidden": sys_block_hidden,
         "columns": {
-            "file_code": {"categories": [str(fc) for fc in file_codes_in_order], "ordered": True},
-            "file_name": {"categories": file_names_in_order, "ordered": True},
+            "file_code": {"categories": [str(fc) for fc in bundle.frames], "ordered": True},
+            "file_name": {"categories": [file_names[fc] for fc in bundle.frames], "ordered": True},
         },
     }
     sys_block = soft_validate(sys_block_dict, ColumnBlockMeta)
@@ -204,302 +71,250 @@ def _process_annotated_data(
         )
     else:
         structure2[sys_block_name] = sys_block
-    meta_obj = meta_obj.model_copy(update={"structure": structure2})
+    return meta_obj.model_copy(update={"structure": structure2})
 
-    raw_data_concat = pd.concat(raw_data_dict.values()).reset_index(drop=True) if raw_data_dict else pd.DataFrame()
-    # Initialize concatenated DataFrame - start empty, will be built column by column
-    ndf_df = pd.DataFrame()
 
-    # Compute and store row index ranges for each file_code
-    file_index_ranges: dict[str, slice] = {}
-    current_idx = 0
-    for file_code, file_raw in raw_data_dict.items():
-        file_len = len(file_raw)
-        file_index_ranges[file_code] = slice(current_idx, current_idx + file_len)
-        current_idx += file_len
+def _gather_source(
+    bundle: SourceBundle, source_spec: str | dict[str, str], orig_cn: str, cn: str, generated: bool
+) -> pd.Series | None:
+    """Resolve and concatenate a column's source series across all files.
 
-    all_cns = dict()
+    Returns None when the column is missing/empty everywhere: declared in meta but absent
+    from the source files -> skipped in df (meta categories are reconciled later).
+    """
+    per_file_series: list[pd.Series] = []
+    for file_code, file_raw_data in bundle.frames.items():
+        # Determine source column name for this file:
+        # a dict maps file codes (with 'default' then orig_cn as fallbacks); a string applies to all files
+        if isinstance(source_spec, dict):
+            sn = source_spec.get(file_code, source_spec.get("default", orig_cn))
+        else:
+            sn = source_spec
+
+        if sn not in file_raw_data:
+            if not generated:  # bypass warning for columns marked as being generated later
+                warn(f"Column {sn} not found in file {file_code}")
+            s = pd.Series(index=file_raw_data.index, dtype=object, name=cn)  # Empty series with same index
+        elif file_raw_data[sn].isna().all():
+            warn(f"Column {sn} is empty in file {file_code} and thus ignored")
+            s = pd.Series(index=file_raw_data.index, dtype=object, name=cn)  # Empty series with same index
+        else:
+            s = file_raw_data[sn].copy()
+            s.name = cn  # Set name early
+        per_file_series.append(s)
+
+    if not per_file_series:
+        return None
+    s = pd.concat(per_file_series).reset_index(drop=True)
+    return None if s.isna().all() else s
+
+
+def _apply_transforms(
+    s: pd.Series, mcm: ColumnMeta, bundle: SourceBundle, ndf_df: pd.DataFrame, cn: str, hooks: HookEnv
+) -> pd.Series:
+    """Apply translate -> transform -> translate_after -> dtype coercion to a gathered series."""
+    if _is_series_of_lists(s):
+        return s
+    if s.dtype.name == "category":
+        s = s.astype("object")  # This makes it easier to use common ops like replace and fillna
+    if mcm.translate:
+        s = s.astype("str").replace(mcm.translate).replace("nan", None).replace("None", None)
+    if mcm.transform is not None and isinstance(mcm.transform, str):
+        # Transforms are evaluated per-file so they can reference the file's raw data (df)
+        # and the per-file view of the columns processed so far (ndf)
+        transformed_parts: list[pd.Series] = []
+        ranges = bundle.ranges()
+        for file_code, file_raw_data in bundle.frames.items():
+            s_local = s.iloc[ranges[file_code]]
+            transformed = hooks.eval(mcm.transform, s=s_local, df=file_raw_data, ndf=ndf_df.iloc[ranges[file_code]])
+            transformed_parts.append(pd.Series(transformed, index=s_local.index, name=cn))
+        s = pd.concat(transformed_parts, ignore_index=True)
+    if mcm.translate_after:
+        s = pd.Series(s).astype("str").replace(mcm.translate_after).replace("nan", None).replace("None", None)
+
+    if mcm.datetime:
+        s = pd.to_datetime(s, errors="coerce")
+    elif mcm.continuous:
+        s = pd.to_numeric(s, errors="coerce")
+    return s
+
+
+def _resolve_categories(s: pd.Series, mcm: ColumnMeta, cn: str) -> tuple[pd.Series, ColumnMeta]:
+    """Infer or coerce the series' categories, returning the updated column meta."""
+    if not mcm.categories or _is_series_of_lists(s):
+        return s, mcm
+
+    if mcm.categories == "infer":
+        # Check for ordered warning before we modify s
+        should_warn_ordered = mcm.ordered and not pd.api.types.is_numeric_dtype(s)
+        # s is the source of truth: it has the final translate -> transform -> translate_after values
+        present = set(s.dropna().unique())
+        if mcm.translate and not mcm.transform and set(mcm.translate.values()) >= present:
+            # Infer order from the translation dict; mapping can be many-to-one so dedup preserving order
+            cats = list(dict.fromkeys(str(c) for c in mcm.translate.values() if c in present))
+        else:
+            # Deterministic ordering: numeric dtype and numeric-like strings sort numerically,
+            # otherwise lexicographically
+            if should_warn_ordered:
+                warn(
+                    f"Ordered category {cn} had category: infer. "
+                    "This only works correctly if you want lexicographic ordering!"
+                )
+            s, cats = _deterministic_categories_and_values(s)
+        mcm = mcm.model_copy(update={"categories": cats})  # Persist inferred categories into metadata
+    elif pd.api.types.is_numeric_dtype(s):
+        # Numeric datatype being coerced into categorical - map to nearest category value
+        cats = mcm.categories
+        if not isinstance(cats, list):
+            raise ValueError(f"Categories for {cn} must be a list when series is numeric")
+        try:
+            fcats = np.array(cats).astype(float)
+            s_values_arr = np.asarray(s.values)
+            if s_values_arr.ndim == 0:
+                s_values_arr = s_values_arr.reshape(-1)
+            distances = np.abs(s_values_arr.reshape(-1, 1) - fcats.reshape(1, -1))
+            s = pd.Series(
+                np.array(cats)[distances.argmin(axis=1)],
+                index=s.index,
+                name=s.name,
+                dtype=pd.CategoricalDtype(categories=cats, ordered=mcm.ordered if mcm.ordered is not None else False),
+            )
+            return s, mcm  # Snapping cannot drop values, and s is already the right Categorical
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"Categories for {cn} are not numeric: {cats}") from e
+    else:
+        cats = mcm.categories
+        if not isinstance(cats, list):
+            raise ValueError(f"Categories for {cn} must be a list")
+
+    if isinstance(cats, list):
+        dropped = set(s.dropna().unique()) - set(cats)
+        if dropped:
+            warn(f"Values for {cn} not in categories and will be dropped: {dropped}")
+        final_ordered = mcm.ordered if mcm.ordered is not None else False
+        s = pd.Series(pd.Categorical(s, categories=cats, ordered=final_ordered), name=cn)
+    return s, mcm
+
+
+def _apply_subgroup_transform(
+    bundle: SourceBundle, ndf_df: pd.DataFrame, transform: str, g_cols: list[str], hooks: HookEnv
+) -> pd.DataFrame:
+    """Apply a block-level subgroup transform per-file over the block's columns."""
+    # TODO: Add a subgroups field to ColumnBlockMeta if per-subgroup application is needed
+    transformed_parts: list[pd.DataFrame] = []
+    ranges = bundle.ranges()
+    for file_code, file_raw_data in bundle.frames.items():
+        idx_range = ranges[file_code]
+        transformed_gdf = hooks.eval(
+            transform,
+            gdf=ndf_df[g_cols].iloc[idx_range].copy(),
+            ndf=ndf_df.iloc[idx_range].copy(),  # Per-file processed data view
+            df=file_raw_data,  # Per-file raw data
+        )
+        transformed_parts.append(cast(pd.DataFrame, transformed_gdf))
+    transformed_combined = pd.concat(transformed_parts).reset_index(drop=True)
+    ndf_df[g_cols] = transformed_combined[g_cols].values
+    return ndf_df
+
+
+def _build_columns(bundle: SourceBundle, meta_obj: DataMeta, hooks: HookEnv) -> tuple[pd.DataFrame, DataMeta]:
+    """Build the processed dataframe column by column from the meta structure.
+
+    Returns the new dataframe and meta with the processed structure (create blocks
+    expanded into their generated groups).
+    """
+    raw_data_concat = bundle.concat(reset_index=True)
+    ndf_df = pd.DataFrame()  # Start empty, built column by column
+
+    all_cns: dict[str, str] = {}  # column/group name -> group that claimed it, for duplicate detection
     # Build new structure dict as we process groups (Pydantic models are immutable)
     new_structure: dict[str, ColumnBlockMeta] = {}
-    for group_name, group in meta_obj.structure.items():
+    for group in meta_obj.structure.values():
         if group.name in all_cns:
             raise Exception(f"Group name {group.name} duplicates a column name in group {all_cns[group.name]}")
         all_cns[group.name] = group.name
-        g_cols = []
-        # Process columns in this group
-        # group.columns is Dict[str, ColumnMeta]
-        # Note: scale metadata is already merged with column metadata
-        # by ColumnBlockMeta.merge_scale_with_columns validator
-        # Keep for forward-compat; metadata categories are reconciled later by _fix_meta_categories.
-        # (We do not remove missing columns from meta, we only skip materializing them into df.)
-        updated_columns: dict[str, ColumnMeta] = {}
-        for orig_cn, col_meta in group.columns.items():
-            # Work with Pydantic objects directly
-            # Get the merged column metadata (scale already merged in during validation)
-            mcm = col_meta
-            # Extract source from ColumnMeta - can be str or dict[str, str]
-            source_spec = col_meta.source if col_meta.source is not None else orig_cn
-            scale_meta = group.scale if group.scale is not None else None
 
-            # Col prefix is used to avoid name clashes when different groups naturally share same column names
-            # col_prefix is only in BlockScaleMeta, not ColumnMeta, so get it from scale_meta directly
-            col_prefix = scale_meta.col_prefix if scale_meta is not None and scale_meta.col_prefix is not None else None
-            cn = orig_cn
-            if col_prefix is not None:
-                cn = col_prefix + orig_cn
+        # Col prefix is used to avoid name clashes when different groups naturally share same column names
+        col_prefix = group.scale.col_prefix if group.scale is not None else None
+
+        # Note: scale metadata is already merged with column metadata by the
+        # ColumnBlockMeta.merge_scale_with_columns validator. Missing columns are not removed
+        # from meta, only skipped in df; their categories are reconciled later by _fix_meta_categories.
+        g_cols = []
+        for orig_cn, mcm in group.columns.items():
+            source_spec = mcm.source if mcm.source is not None else orig_cn
+            cn = col_prefix + orig_cn if col_prefix is not None else orig_cn
 
             # Detect duplicate columns in meta - including among those missing or generated
-            # Only flag if they are duplicates even after prefix
             if cn in all_cns:
                 raise Exception(f"Duplicate column name found: '{cn}' in {all_cns[cn]} and {group.name}")
             all_cns[cn] = group.name
 
-            if only_fix_categories:
-                source_spec = cn
-
-            # Extract columns from all files and concatenate immediately
-            per_file_series: list[pd.Series] = []
-            for file_code, file_raw_data in raw_data_dict.items():
-                # Determine source column name for this file
-                if isinstance(source_spec, dict):
-                    # Dict mapping: use file code, fallback to 'default', or use orig_cn
-                    sn = source_spec.get(file_code, source_spec.get("default", orig_cn))
-                else:
-                    # String: use for all files
-                    sn = source_spec
-
-                if sn not in file_raw_data:
-                    if not group.generated:  # bypass warning for columns marked as being generated later
-                        warn(f"Column {sn} not found in file {file_code}")
-                    # Create empty series with same index as file
-                    s = pd.Series(index=file_raw_data.index, dtype=object, name=cn)
-                    per_file_series.append(s)
-                    continue
-
-                if file_raw_data[sn].isna().all():
-                    warn(f"Column {sn} is empty in file {file_code} and thus ignored")
-                    # Create empty series with same index as file
-                    s = pd.Series(index=file_raw_data.index, dtype=object, name=cn)
-                    per_file_series.append(s)
-                    continue
-
-                # Extract raw column value - no processing yet
-                s = file_raw_data[sn].copy()
-                s.name = cn  # Set name early
-                per_file_series.append(s)
-
-            # Concatenate all per-file series immediately - now process on concatenated data
-            if not per_file_series:
-                # No valid series found, skip this column
+            s = _gather_source(bundle, source_spec, orig_cn, cn, group.generated)
+            if s is None:
                 continue
-
-            # Concatenated series ready for processing
-            s: pd.Series = pd.concat(per_file_series).reset_index(drop=True)
-
-            # Declared in meta but missing/empty in all source files -> drop from df and meta.
-            if s.isna().all():
-                continue
-
-            # Store original dtype info if categorical (before any conversions)
-            original_dtype = s.dtype
-            if not only_fix_categories and not _is_series_of_lists(s):
-                if original_dtype.name == "category":
-                    s = s.astype("object")  # This makes it easier to use common ops like replace and fillna
-                if mcm.translate:
-                    s = s.astype("str").replace(mcm.translate).replace("nan", None).replace("None", None)
-                if mcm.transform is not None and isinstance(mcm.transform, str):
-                    # For transform, process per-file using index ranges
-                    transformed_parts: list[pd.Series] = []
-                    for file_code, file_raw_data in raw_data_dict.items():
-                        idx_range = file_index_ranges[file_code]
-                        s_local = s.iloc[idx_range]
-                        ndf_local = ndf_df.iloc[idx_range]
-                        transformed = eval(
-                            mcm.transform,
-                            {
-                                "s": s_local,
-                                "df": file_raw_data,  # Per-file raw data
-                                "ndf": ndf_local,  # Per-file processed data view
-                                "pd": pd,
-                                "np": np,
-                                "stk": stk,
-                                **constants,
-                            },
-                        )
-
-                        s_out = pd.Series(transformed, index=s_local.index, name=cn)
-                        transformed_parts.append(s_out)
-                    s = pd.concat(transformed_parts, ignore_index=True)
-                if mcm.translate_after:
-                    s = (
-                        pd.Series(s)
-                        .astype("str")
-                        .replace(mcm.translate_after)
-                        .replace("nan", None)
-                        .replace("None", None)
-                    )
-
-                if mcm.datetime:
-                    s = pd.to_datetime(s, errors="coerce")
-                elif mcm.continuous:
-                    s = pd.to_numeric(s, errors="coerce")
-
+            s = _apply_transforms(s, mcm, bundle, ndf_df, cn, hooks)
             s.name = cn  # Ensure name is set
+            s, mcm = _resolve_categories(s, mcm, cn)
 
-            # Category inference on concatenated data
-            if mcm.categories and not _is_series_of_lists(s):
-                if mcm.categories == "infer":
-                    # Check for ordered warning before we modify s
-                    should_warn_ordered = mcm.ordered and not pd.api.types.is_numeric_dtype(s)
-                    # Infer categories from the transformed data (s has already gone through
-                    # translate -> transform -> translate_after pipeline)
-                    # Always use s as the source of truth - it has the final transformed values
-                    if mcm.translate and not mcm.transform and set(mcm.translate.values()) >= set(s.dropna().unique()):
-                        # Infer order from translation dict
-                        translate_values = list(mcm.translate.values())
-                        cats = [str(c) for c in translate_values if c in s.dropna().unique()]
-                        # As mapping can be many-to-one, we need to use unique and preserve order
-                        inferred_cats = list(dict.fromkeys(cats))
-                        # Update metadata with inferred categories (preserves translation dict order)
-                        mcm = mcm.model_copy(update={"categories": inferred_cats})
-                    else:
-                        # Deterministic ordering:
-                        # - numeric dtype -> numeric sort
-                        # - numeric-like strings -> numeric sort
-                        # - otherwise -> lexicographic sort
-                        if should_warn_ordered:
-                            warn(
-                                f"Ordered category {cn} had category: infer. "
-                                "This only works correctly if you want lexicographic ordering!"
-                            )
-                        s, inferred_cats = _deterministic_categories_and_values(s)
-                        # Update metadata with inferred categories
-                        mcm = mcm.model_copy(update={"categories": inferred_cats})
-                    cats = inferred_cats
-                elif pd.api.types.is_numeric_dtype(s):
-                    # Numeric datatype being coerced into categorical - map to nearest category value
-                    cats = mcm.categories
-                    if not isinstance(cats, list):
-                        raise ValueError(f"Categories for {cn} must be a list when series is numeric")
-
-                    try:
-                        fcats = np.array(cats).astype(float)
-                        s_values_arr = np.asarray(s.values)
-                        if s_values_arr.ndim == 0:
-                            s_values_arr = s_values_arr.reshape(-1)
-                        cats_array = np.array(cats)
-                        s_values_reshaped = s_values_arr.reshape(-1, 1)
-                        fcats_reshaped = fcats.reshape(1, -1)
-                        distances = np.abs(s_values_reshaped - fcats_reshaped)
-                        indices = distances.argmin(axis=1)
-                        s = pd.Series(
-                            cats_array[indices],
-                            index=s.index,
-                            name=s.name,
-                            dtype=pd.CategoricalDtype(
-                                categories=cats, ordered=mcm.ordered if mcm.ordered is not None else False
-                            ),
-                        )
-                    except (ValueError, TypeError) as e:
-                        raise ValueError(f"Categories for {cn} are not numeric: {cats}") from e
-                else:
-                    cats = mcm.categories
-                    if not isinstance(cats, list):
-                        raise ValueError(f"Categories for {cn} must be a list")
-
-                if isinstance(cats, list):
-                    dropped = set(s.dropna().unique()) - set(cats)
-                    if dropped:
-                        warn(f"Values for {cn} not in categories and will be dropped: {dropped}")
-                    # Use updated ordered flag if we modified it during inference
-                    final_ordered = mcm.ordered if mcm.ordered is not None else False
-                    s = pd.Series(
-                        pd.Categorical(s, categories=cats, ordered=final_ordered),
-                        name=cn,
-                    )
-
-            # Add column directly to concatenated DataFrame
             ndf_df[cn] = s
             g_cols.append(cn)
 
-            # Store updated column metadata (with inferred categories if applicable)
-            updated_columns[orig_cn] = mcm
-
         if group.subgroup_transform is not None:
-            # subgroups is not in ColumnBlockMeta, so we'll use g_cols as default
-            subgroups = [g_cols]  # TODO: Add subgroups field to ColumnBlockMeta if needed
-            for sg in subgroups:
-                # Apply per-file using index ranges
-                subgroup_transformed_parts: list[pd.DataFrame] = []
-                for file_code in raw_data_dict.keys():
-                    idx_range = file_index_ranges[file_code]
-                    gdf_local = ndf_df[sg].iloc[idx_range].copy()
-                    ndf_local = ndf_df.iloc[idx_range].copy()
-                    transformed_gdf = eval(
-                        group.subgroup_transform,
-                        {
-                            "gdf": gdf_local,
-                            "ndf": ndf_local,  # Per-file processed data view
-                            "df": file_raw_data,  # Per-file raw data
-                            "pd": pd,
-                            "np": np,
-                            "stk": stk,
-                            **constants,
-                        },
-                    )
-                    subgroup_transformed_parts.append(transformed_gdf)
-                # Concatenate and assign back
-                transformed_combined = pd.concat(subgroup_transformed_parts).reset_index(drop=True)
-                ndf_df[sg] = transformed_combined[sg].values
+            ndf_df = _apply_subgroup_transform(bundle, ndf_df, group.subgroup_transform, g_cols, hooks)
+
         # Handle create blocks - may add new groups to structure
         if group.create is not None:
             create_source_df = ndf_df.combine_first(raw_data_concat) if not raw_data_concat.empty else ndf_df
             for newdf, newmeta_dict in _create_new_columns_and_metas(
                 create_source_df,
                 group,
-                topics=constants.get("topics", None),
-                sets=constants.get("sets", None),
+                topics=hooks.constants.get("topics", None),
+                sets=hooks.constants.get("sets", None),
             ):
                 ndf_df = ndf_df.combine_first(newdf)
                 new_group_meta = soft_validate(newmeta_dict, ColumnBlockMeta)
                 new_structure[new_group_meta.name] = new_group_meta
-            # Create a copy of group without the create field
-            group = group.model_copy(update={"create": None})
+            group = group.model_copy(update={"create": None})  # The processed group no longer creates
 
-        # Add processed group to structure
         new_structure[group.name] = group
 
-    if meta_obj.postprocessing is not None and not only_fix_categories:
-        globs = {
-            "pd": pd,
-            "np": np,
-            "sp": sp,
-            "stk": stk,
-            "df": ndf_df,
-            **einfo,
-            **constants,
-        }
-        exec(_str_from_list(meta_obj.postprocessing), globs)
-        ndf_df = globs["df"]
-
     # Update meta with new structure (including any groups created during processing)
-    meta_obj = meta_obj.model_copy(update={"structure": new_structure})
+    return ndf_df, meta_obj.model_copy(update={"structure": new_structure})
 
-    # Fix categories after postprocessing
-    # Also replaces infer with the actual categories
-    meta_obj = _fix_meta_categories(meta_obj, ndf_df, warnings=True)
-    # Ensure we have a DataMeta object
-    if not isinstance(meta_obj, DataMeta):
-        meta_obj = soft_validate(meta_obj, DataMeta)
 
+def _apply_exclusions(ndf_df: pd.DataFrame, meta_obj: DataMeta, opts: ProcessOpts) -> Dataset:
+    """Filter out rows listed in meta `excluded` and optionally keep the original_inds column."""
     ndf_df["original_inds"] = np.arange(len(ndf_df))
-    if meta_obj.excluded and not ignore_exclusions:
+    if meta_obj.excluded and not opts.ignore_exclusions:
         excl_inds = [i for i, _ in meta_obj.excluded]
         ndf_df = ndf_df[~ndf_df["original_inds"].isin(excl_inds)]
-    if not add_original_inds:
+    if not opts.add_original_inds:
         ndf_df.drop(columns=["original_inds"], inplace=True)
+    return Dataset(ndf_df, meta_obj)
 
-    # Return with meta as dict if requested (for backward compatibility)
-    if return_meta:
-        return (ndf_df, meta_obj)
-    return ndf_df
+
+def process(bundle: SourceBundle, meta_obj: DataMeta, opts: ProcessOpts) -> Dataset:
+    """Run the annotation pipeline stages on loaded source data."""
+    hooks = HookEnv(bundle.env, meta_obj.constants)
+    file_names = _file_meta_map(bundle.frames)
+
+    # Run preprocessing per file
+    if meta_obj.preprocessing is not None:
+        for fc in bundle.frames:
+            bundle.frames[fc] = hooks.exec_df(
+                meta_obj.preprocessing, bundle.frames[fc], file_code=fc, file_name=file_names[fc]
+            )
+
+    # File provenance columns must survive end-to-end (also if preprocessing dropped/mutated them)
+    meta_obj = _inject_files_block(bundle, meta_obj, file_names)
+
+    ndf_df, meta_obj = _build_columns(bundle, meta_obj, hooks)
+
+    if meta_obj.postprocessing is not None:
+        ndf_df = hooks.exec_df(meta_obj.postprocessing, ndf_df)
+
+    # Fix categories after postprocessing; also replaces "infer" with the actual categories
+    meta_obj = _fix_meta_categories(meta_obj, ndf_df, warnings=True)
+
+    return _apply_exclusions(ndf_df, meta_obj, opts)

--- a/salk_toolkit/io/readers.py
+++ b/salk_toolkit/io/readers.py
@@ -1,8 +1,17 @@
-"""File tracking and path remapping for reproducible packaging."""
+"""File tracking, path remapping for reproducible packaging, and raw tabular format readers."""
+
+import warnings
+from typing import Any
+
+import pandas as pd
+import pyreadstat  # type: ignore[import-untyped]
 
 
 # This is here so we can easily track which files would be needed for a model
 # so we can package them together if needed
+
+# NB! for unpacking to work, the processing needs to not be changed w.r.t. paths
+# For this, we only map values when loading actual files, not when calling other functions here
 
 #  a global list of files that have been loaded
 stk_loaded_files_set = set()
@@ -46,3 +55,29 @@ def set_file_map(file_map: dict[str, str]) -> None:
     """
     global stk_file_map
     stk_file_map = file_map.copy()
+
+
+_TABULAR_EXTENSIONS = ["csv", "gz", "sav", "dta", "xls", "xlsx", "xlsm", "xlsb", "odf", "ods", "odt"]
+
+
+def _read_tabular(
+    mapped_file: str, extension: str, read_opts: dict[str, Any]
+) -> tuple[pd.DataFrame, dict[str, object]]:
+    """Read a raw tabular file (csv/sav/excel family), returning the frame and any reader metadata."""
+    if extension in ["csv", "gz"]:
+        csv_defaults: dict[str, Any] = {"low_memory": False}
+        if read_opts.get("engine") == "python":
+            csv_defaults.pop("low_memory")  # python engine doesn't support low_memory
+        return pd.read_csv(mapped_file, **{**csv_defaults, **read_opts}), {}  # type: ignore[call-overload]
+    if extension in ["sav", "dta"]:
+        read_fn = getattr(pyreadstat, "read_" + mapped_file[-3:].lower())
+        with warnings.catch_warnings():  # While pyreadstat has not been updated to pandas 2.2 standards
+            warnings.simplefilter("ignore")
+            raw_data, fmeta = read_fn(
+                mapped_file,
+                **{"apply_value_formats": True, "dates_as_pandas_datetime": True},
+                **read_opts,
+            )
+        # fmeta fields can be used in hooks just like self-defined constants
+        return raw_data, dict(fmeta.__dict__)
+    return pd.read_excel(mapped_file, **read_opts), {}  # type: ignore[call-overload]

--- a/salk_toolkit/io/sources.py
+++ b/salk_toolkit/io/sources.py
@@ -1,15 +1,15 @@
-"""Loading of data files into per-file dataframes, including nested annotated sources."""
+"""Loading of data sources into per-file SourceBundles, including nested annotated sources."""
 
 import os
-import warnings
 from collections.abc import Iterable
 from typing import Any, cast
 
 import pandas as pd
-import pyreadstat  # type: ignore[import-untyped]
 
 from salk_toolkit import utils
 from salk_toolkit.utils import (
+    read_json,
+    read_yaml,
     warn,
 )
 from salk_toolkit.validation import (
@@ -19,8 +19,10 @@ from salk_toolkit.validation import (
 )
 
 from salk_toolkit.io import readers
-from salk_toolkit.io.core import _deterministic_categories_and_values
+from salk_toolkit.io.core import Dataset, ProcessOpts, SourceBundle, _deterministic_categories_and_values
 from salk_toolkit.io.meta import _fix_meta_categories
+from salk_toolkit.io.parquet import read_parquet_with_metadata
+from salk_toolkit.io.pipeline import process
 
 
 def _reconcile_categories(
@@ -106,19 +108,16 @@ def _load_data_files(
     data_files: list[FileDesc],
     path: str | None,
     read_opts: dict[str, Any] | None = None,
-    ignore_exclusions: bool = False,
-    only_fix_categories: bool = False,
-    add_original_inds: bool = False,
-) -> tuple[dict[str, pd.DataFrame], DataMeta | None, dict[str, object]]:
+    opts: ProcessOpts = ProcessOpts(),
+) -> SourceBundle:
     """Internal helper to load files defined in metadata or descriptions.
 
-    Returns per-file dataframes keyed by file code, keeping them separate for per-file processing.
+    Returns a SourceBundle keeping the per-file dataframes separate for per-file processing.
     """
 
-    from salk_toolkit.io.datasets import read_annotated_data  # deferred import breaks the sources<->datasets cycle
-
     raw_data_dict: dict[str, pd.DataFrame] = {}
-    metas, einfo = [], {}
+    meta: DataMeta | None = None
+    einfo: dict[str, object] = {}
     if read_opts is None:
         read_opts = {}
 
@@ -135,7 +134,8 @@ def _load_data_files(
 
     for fi, fd in enumerate(data_files):
         data_file = fd.file
-        opts = fd.opts or read_opts
+        fopts = fd.opts or read_opts
+        result_meta: DataMeta | None = None
         file_code = fd.code if fd.code is not None else f"F{fi}"  # Default to F0, F1, F2, etc.
         if path:
             # path is guaranteed to be str here due to the if check
@@ -152,36 +152,15 @@ def _load_data_files(
             if extension == "json":
                 warn(f"Processing {data_file}")  # Print this to separate warnings for input jsons from main
             # Pass in orig_data_file here as it might loop back to this function here and we need to preserve paths
-            raw_data, result_meta = read_annotated_data(
-                cast(str, data_file),
-                infer=False,
-                return_meta=True,
-                ignore_exclusions=ignore_exclusions,
-                only_fix_categories=only_fix_categories,
-                add_original_inds=add_original_inds,
-            )
+            raw_data, result_meta = _load_dataset(cast(str, data_file), opts)
             if result_meta is not None:
-                metas.append(soft_validate(result_meta, DataMeta, warnings=True))
-        elif extension in ["csv", "gz"]:
-            read_opts = cast(dict[str, Any], opts) if opts else {}
-            csv_defaults: dict[str, Any] = {"low_memory": False}
-            if read_opts.get("engine") == "python":
-                csv_defaults.pop("low_memory")  # python engine doesn't support low_memory
-            raw_data = pd.read_csv(cast(str, mapped_file), **{**csv_defaults, **read_opts})  # type: ignore[call-overload]
-        elif extension in ["sav", "dta"]:
-            read_fn = getattr(pyreadstat, "read_" + (mapped_file[-3:]).lower())
-            with warnings.catch_warnings():  # While pyreadstat has not been updated to pandas 2.2 standards
-                warnings.simplefilter("ignore")
-                read_opts = cast(dict[str, Any], opts) if opts else {}
-                raw_data, fmeta = read_fn(
-                    cast(str, mapped_file),
-                    **{"apply_value_formats": True, "dates_as_pandas_datetime": True},
-                    **read_opts,
-                )
-                einfo.update(fmeta.__dict__)  # Allow the fields in meta to be used just like self-defined constants
-        elif extension in ["xls", "xlsx", "xlsm", "xlsb", "odf", "ods", "odt"]:
-            read_opts = cast(dict[str, Any], opts) if opts else {}
-            raw_data = pd.read_excel(cast(str, mapped_file), **read_opts)  # type: ignore[call-overload]
+                # TODO: one should also merge the structures in case the columns don't match
+                meta = soft_validate(result_meta, DataMeta, warnings=True)  # Last annotated source wins
+        elif extension in readers._TABULAR_EXTENSIONS:
+            raw_data, fenv = readers._read_tabular(
+                cast(str, mapped_file), extension, cast(dict[str, Any], fopts) if fopts else {}
+            )
+            einfo.update(fenv)  # Allow the fields in reader meta to be used just like self-defined constants
         else:
             raise Exception(f"Not a known file format for {data_file}: {extension}")
 
@@ -201,11 +180,7 @@ def _load_data_files(
         # we must NOT overwrite its internal per-file provenance columns (file_code/file_name),
         # otherwise we'd collapse them into a single file.
         preserve_annotated_multi = (
-            extension in ["json", "yaml", "parquet"]
-            and "result_meta" in locals()
-            and result_meta is not None
-            and getattr(result_meta, "files", None) is not None
-            and len(cast(list[object], getattr(result_meta, "files"))) > 1
+            result_meta is not None and result_meta.files is not None and len(result_meta.files) > 1
         )
         if not preserve_annotated_multi:
             raw_data["file_code"] = file_code
@@ -222,22 +197,89 @@ def _load_data_files(
 
         raw_data_dict[file_code] = raw_data
 
-    if metas:  # Do we have any metainfo?
-        meta = metas[-1]
+    if meta is None:  # Do we have any metainfo?
+        return SourceBundle(frames=raw_data_dict, env=einfo)
 
-        # Reconcile categoricals across files: pd.concat collapses categoricals with
-        # different category lists to object dtype, so we need to re-unify them first.
-        if len(raw_data_dict) > 1:
-            reconciled_dtypes = _reconcile_categories(raw_data_dict, warnings=False)
-            for fc, rdf in raw_data_dict.items():
-                for col, dtype in reconciled_dtypes.items():
-                    if col in rdf.columns:
-                        raw_data_dict[fc][col] = rdf[col].astype("object").astype(dtype)
+    # Reconcile categoricals across files: pd.concat collapses categoricals with
+    # different category lists to object dtype, so we need to re-unify them first.
+    if len(raw_data_dict) > 1:
+        reconciled_dtypes = _reconcile_categories(raw_data_dict, warnings=False)
+        for fc, rdf in raw_data_dict.items():
+            for col, dtype in reconciled_dtypes.items():
+                if col in rdf.columns:
+                    raw_data_dict[fc][col] = rdf[col].astype("object").astype(dtype)
 
-        # This will fix categories inside meta too - use concatenated view for this
-        fdf = pd.concat(raw_data_dict.values())
-        meta = _fix_meta_categories(meta, fdf, warnings=False)
-        # TODO: one should also merge the structures in case the columns don't match
-        return raw_data_dict, meta, einfo
+    # This will fix categories inside meta too - use concatenated view for this
+    fdf = pd.concat(raw_data_dict.values())
+    meta = _fix_meta_categories(meta, fdf, warnings=False)
+    return SourceBundle(frames=raw_data_dict, env=einfo, meta=meta)
+
+
+def _read_meta_input(meta_fname: str | None, meta: DataMeta | dict[str, object] | None) -> DataMeta:
+    """Load the metafile (or accept an in-memory meta dict) and validate to DataMeta."""
+    meta_input: DataMeta | dict[str, object] | None = meta
+    if meta_fname is not None:
+        metafile = cast(dict[str, str], readers.stk_file_map).get(meta_fname, meta_fname)
+        ext = os.path.splitext(metafile)[1]
+        if ext == ".yaml":
+            meta_raw = read_yaml(metafile)
+        elif ext == ".json":
+            meta_raw = read_json(metafile)
+        else:
+            raise Exception(f"Unknown meta file format {ext} for file: {meta_fname}")
+        assert isinstance(meta_raw, dict), "Meta file must contain a dict"
+        meta_input = dict(meta_raw)  # Cast to ensure object values
+    if meta_input is None:
+        raise ValueError("Metadata cannot be None")
+    return soft_validate(meta_input, DataMeta, warnings=True)
+
+
+def _load_meta_sources(
+    meta_obj: DataMeta, meta_fname: str | None, data_file: str | None, opts: ProcessOpts
+) -> SourceBundle:
+    """Resolve the meta's file list (or a data_file override) and load it into a SourceBundle."""
+    if data_file is not None:
+        # data_file override: use it directly
+        files_list = [FileDesc(file=data_file, opts=meta_obj.read_opts)]
+    elif meta_obj.files is not None:
+        files_list = meta_obj.files
     else:
-        return raw_data_dict, None, einfo
+        raise ValueError("No files provided in metadata")
+
+    bundle = _load_data_files(
+        files_list,
+        path=meta_fname if meta_fname is not None else data_file,
+        read_opts=meta_obj.read_opts,
+        opts=opts,
+    )
+    if bundle.meta is not None:
+        warn("Processing main meta file")  # Print this to separate warnings for input jsons from main
+    return bundle
+
+
+def _load_dataset(path: str, opts: ProcessOpts) -> Dataset:
+    """Load an already-annotated source: a metafile or a parquet with embedded meta. No inference."""
+    ext = os.path.splitext(path)[1]
+    if ext in {".json", ".yaml"}:
+        return _process_annotated_data(meta_fname=path, opts=opts)
+    df, full_meta = read_parquet_with_metadata(path)
+    return Dataset(df, full_meta.data if full_meta is not None else None)
+
+
+# Default usage with mature metafile: _process_annotated_data(<metafile name>)
+# When figuring out the metafile, it can also be run as: _process_annotated_data(meta=<dict>, data_file=<>)
+
+
+def _process_annotated_data(
+    meta_fname: str | None = None,
+    meta: DataMeta | dict[str, object] | None = None,
+    data_file: str | None = None,
+    opts: ProcessOpts = ProcessOpts(),
+    return_raw: bool = False,
+) -> Dataset:
+    """Process annotated data according to metadata specifications."""
+    meta_obj = _read_meta_input(meta_fname, meta)
+    bundle = _load_meta_sources(meta_obj, meta_fname, data_file, opts)
+    if return_raw:  # Concatenated raw data, for debugging metafiles
+        return Dataset(bundle.concat(), meta_obj)
+    return process(bundle, meta_obj, opts)

--- a/salk_toolkit/plots.py
+++ b/salk_toolkit/plots.py
@@ -1169,7 +1169,7 @@ def _cat_to_cont_axis(
 
     # Date-like strings -> parse to datetime and use temporal axis.
     if utils.is_date_str_series(raw):
-        x_dt = pd.to_datetime(raw, errors="coerce")
+        x_dt = pd.to_datetime(raw, errors="coerce", format="mixed")
         # Keep cont axis values JSON-friendly and timezone-stable:
         # use explicit UTC instants so Vega doesn't show local-time shifts (02 AM, etc.).
         data[cont_col] = x_dt.dt.strftime("%Y-%m-%dT00:00:00").where(x_dt.notna(), None)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2457,7 +2457,7 @@ class TestMetadataUtilities:
 
     def test_get_original_column_names_bug_fix(self):
         """Test that get_original_column_names handles strings correctly (bug fix)"""
-        from salk_toolkit.io import _get_original_column_names as get_original_column_names
+        from salk_toolkit.io.meta import _get_original_column_names as get_original_column_names
 
         # Test simple string columns (this was the bug case)
         meta_simple = make_data_meta(
@@ -3107,6 +3107,36 @@ class TestMultiSourceColumns:
         assert "value" in df.columns
         assert df.loc[df["file_code"] == "F0", "value"].notna().all()
         assert df.loc[df["file_code"] == "F1", "value"].isna().all()
+
+    def test_multi_source_per_file_opts_do_not_leak(self, temp_dir):
+        """One file's read opts must not become the fallback for subsequent files"""
+        file1 = temp_dir / "semi.csv"
+        file2 = temp_dir / "comma.csv"
+        meta_file = temp_dir / "meta.json"
+
+        file1.write_text("id;value\n1;10\n2;20\n")
+        file2.write_text("id,value\n3,30\n4,40\n")
+
+        meta = {
+            "files": [
+                {"file": "semi.csv", "code": "F0", "opts": {"sep": ";"}},
+                {"file": "comma.csv", "code": "F1"},
+            ],
+            "structure": [
+                {
+                    "name": "test",
+                    "columns": {
+                        "id": {"continuous": True},
+                        "value": {"continuous": True},
+                    },
+                }
+            ],
+        }
+        write_json(meta_file, meta)
+
+        df = read_annotated_data(str(meta_file))
+        assert df["value"].notna().all()
+        assert sorted(df["value"]) == [10, 20, 30, 40]
 
     def test_multi_source_preprocessing_per_file(self, temp_dir):
         """Test preprocessing runs per file with correct context"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -522,7 +522,7 @@ class TestTimeAndRandomUtilities:
 
     def test_str_series_roundtrip_with_io_converters(self):
         """Test helpers on the string output of IO converters."""
-        from salk_toolkit.io import _convert_datetime_series_to_categorical, _convert_number_series_to_categorical
+        from salk_toolkit.io.core import _convert_datetime_series_to_categorical, _convert_number_series_to_categorical
 
         # numeric strings -> formatted numeric strings
         num_s = pd.Series(["1", "2.5", None, "-4"])


### PR DESCRIPTION
Second of a two-PR stack implementing `specs/io-pipeline-refactor-design.md`. **Stacked on #53** (the pure package move) — review/merge that first; this PR is all the *logic* changes, as a clean diff over the already-placed package.

### `e78ce92` — Refactor the internals
- **Deadwood** (verified caller-free across STK/SIP/tools): `only_fix_categories`, `_process_annotated_data(raw_data=)`, the `data_meta` kwarg fixup, the `**kwargs` swallow (unknown args are now `TypeError`), the `"result_meta" in locals()` introspection, the duplicated overload towers / `if return_meta:` double-calls.
- **Decomposition**: `Dataset` / `SourceBundle` / `ProcessOpts` / `HookEnv` value types (one hook environment replacing five hand-built globals dicts); `_process_annotated_data` (430 lines) → ~20 lines of orchestration over named stages (`_gather_source`, `_apply_transforms`, `_resolve_categories`, `_inject_files_block`, `_apply_exclusions`); `readers._read_tabular` and `sources._load_dataset` factored out (the latter replacing #53's deferred cycle-break import with a proper call).
- **Unification & fixes**: `read_and_process_data` loads through the shared `_load_data_files`, its duplicate `_fix_meta_categories` pass gone; per-file `read_opts` no longer leak into subsequent files (regression test added); `subgroup_transform` sees the matching per-file raw `df` (was a stale loop variable — wrong for multi-file data); private test imports move to submodule paths.

### `9bf0ca2` — Date-axis flakiness fix (drive-by)
Pre-existing `plots._cat_to_cont_axis` bug: pandas 3 guesses date formats from the first element, so `test_lines_date` failed ~1/15 runs on `main`. Fixed with `format="mixed"`.

## Ordering note
`read_and_process_data` drops its `**kwargs` tolerance, so **merge salk-ee/salk_internal_package#95 first** (it removes the only caller relying on the old swallow, an ineffective `file_map=`).

## Verification
- Full STK suite green (222 passed; only the pre-existing arviz `test_lines_hdi_basic` deselected); `pyright -p .` 0 errors; ruff clean — after every commit.
- SIP quick suite 383 passed against the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)