### PR TITLE
Optimize the plot pipeline (~4-10x) — categorical/continuous wide-agg, pushdown, get_plot_fn

### DIFF
--- a/salk_toolkit/plots.py
+++ b/salk_toolkit/plots.py
@@ -2201,6 +2201,7 @@ def _sample_ordered_population_group(
 @stk_plot(
     "ordered_population_sampled",
     data_format="raw",
+    sample=1000,
     factor_columns=3,
     aspect_ratio=(1.0 / 1.0),
     args={"sample_size": "int", "seed": "int"},

--- a/salk_toolkit/pp/__init__.py
+++ b/salk_toolkit/pp/__init__.py
@@ -41,6 +41,7 @@ from .registry import (
     _stk_deregister as _stk_deregister,
 )
 from .meta import (
+    _extract_column_meta_cached as _extract_column_meta_cached,
     _update_data_meta_with_pp_desc as _update_data_meta_with_pp_desc,
 )
 from .matching import (

--- a/salk_toolkit/pp/__init__.py
+++ b/salk_toolkit/pp/__init__.py
@@ -35,7 +35,6 @@ from .registry import (
     get_plot_fn as get_plot_fn,
     get_plot_meta as get_plot_meta,
     _ensure_plot_registry_loaded as _ensure_plot_registry_loaded,
-    _get_plot_fn as _get_plot_fn,
     _stk_deregister as _stk_deregister,
 )
 from .meta import (

--- a/salk_toolkit/pp/__init__.py
+++ b/salk_toolkit/pp/__init__.py
@@ -32,11 +32,9 @@ from .registry import (
     registry as registry,
     registry_meta as registry_meta,
     stk_plot as stk_plot,
-    stk_plot_defaults as stk_plot_defaults,
     get_plot_fn as get_plot_fn,
     get_plot_meta as get_plot_meta,
     _ensure_plot_registry_loaded as _ensure_plot_registry_loaded,
-    _get_all_plots as _get_all_plots,
     _get_plot_fn as _get_plot_fn,
     _stk_deregister as _stk_deregister,
 )

--- a/salk_toolkit/pp/common.py
+++ b/salk_toolkit/pp/common.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from copy import copy as shallow_copy, deepcopy
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, cast
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, cast
 
 import altair as alt
-import numpy as np
 import pandas as pd
 from pydantic_extra_types.color import Color
 
@@ -77,7 +76,7 @@ class PlotInput:
         return out
 
 
-def _normalize_color_dict(scale: Dict[str, Color | str] | None) -> Dict[str, str] | None:
+def _normalize_color_dict(scale: Mapping[str, Color | str] | None) -> Dict[str, str] | None:
     """Convert Color objects to hex strings so Altair accepts the scale."""
 
     if not scale:
@@ -96,49 +95,9 @@ def _normalize_color_dict(scale: Dict[str, Color | str] | None) -> Dict[str, str
 AltairChart = alt.Chart | alt.LayerChart | alt.FacetChart | alt.VConcatChart | alt.HConcatChart | alt.ConcatChart
 
 
-def _augment_draws(
-    data: pd.DataFrame,
-    factors: Sequence[str] | None = None,
-    n_draws: int | None = None,
-    threshold: int = 50,
-) -> pd.DataFrame:
-    """Augment each draw with bootstrap data from across whole population.
-
-    Ensures at least ``threshold`` samples per bucket.
-    """
-
-    if n_draws is None:
-        n_draws = data.draw.max() + 1
-
-    assert n_draws is not None, "n_draws must be set"
-
-    if factors:  # Run recursively on each factor separately and concatenate results
-        factors_list = list(factors)
-        if data[["draw"] + factors_list].value_counts().min() >= threshold:
-            return data  # This takes care of large datasets fast
-        return (
-            data.groupby(factors_list, observed=False)
-            .apply(_augment_draws, n_draws=n_draws, threshold=threshold)
-            .reset_index(drop=True)
-        )  # Slow-ish, but only needed on small data now
-
-    # Get count of values for each draw
-    draw_counts = data["draw"].value_counts()  # Get value counts of existing draws
-    if len(draw_counts) < n_draws:  # Fill in completely missing draws
-        draw_counts = (draw_counts + pd.Series(0, index=range(n_draws))).fillna(0).astype(int)
-
-    # If no new draws needed, just return original
-    if draw_counts.min() >= threshold:
-        return data
-
-    # Generate an index for new draws
-    new_draws = [d for d, c in draw_counts[draw_counts < threshold].items() for _ in range(threshold - c)]
-
-    # Generate new draws
-    new_rows = data.iloc[np.random.choice(len(data), len(new_draws)), :].copy()
-    new_rows = new_rows.assign(draw=new_draws)
-
-    return pd.concat([data, new_rows])
+# --------------------------------------------------------
+#          SHARED UTILITY FUNCTIONS
+# --------------------------------------------------------
 
 
 def _get_cat_num_vals(

--- a/salk_toolkit/pp/common.py
+++ b/salk_toolkit/pp/common.py
@@ -38,11 +38,16 @@ class FacetMeta:
     """Facet definition consumed by the plotting pipeline."""
 
     col: str  # Column name used for faceting within the processed dataframe
-    ocol: str  # Original column (before translations or label tweaks)
+    ocol: str = ""  # Original column (before translations or label tweaks); defaults to ``col``
     order: List[str] = field(default_factory=list)  # Ordered categories for the facet column
     colors: object | None = None  # Altair-ready color definition (often `alt.Scale`, `alt.Undefined`, or a dict)
     neutrals: List[str] = field(default_factory=list)  # Likert neutral categories to mute in gradients
     meta: ColumnMeta = field(default_factory=ColumnMeta)  # Full metadata reference for the facet column
+
+    def __post_init__(self) -> None:
+        """Default ``ocol`` to ``col`` when not given."""
+        if not self.ocol:
+            self.ocol = self.col
 
 
 @dataclass
@@ -50,8 +55,8 @@ class PlotInput:
     """Structured container passed to individual plot functions."""
 
     data: pd.DataFrame
-    col_meta: Dict[str, GroupOrColumnMeta]
     value_col: str
+    col_meta: Dict[str, GroupOrColumnMeta] = field(default_factory=dict)
     cat_col: Optional[str] = None
     val_format: str = "%"
     val_range: Optional[Tuple[Optional[float], Optional[float]]] = None

--- a/salk_toolkit/pp/common.py
+++ b/salk_toolkit/pp/common.py
@@ -13,13 +13,11 @@ from pydantic_extra_types.color import Color
 from salk_toolkit.validation import ColumnMeta, GroupOrColumnMeta, PlotDescriptor
 
 
-def _meta_to_plain(meta: ColumnMeta) -> Dict[str, Any]:
-    """Return a plain dict copy of column metadata."""
-
-    return meta.model_dump(mode="python")
-
-
-def _question_meta_clone(base_meta: GroupOrColumnMeta, categories: Sequence[str] | None = None) -> GroupOrColumnMeta:
+def _question_meta_clone(
+    base_meta: GroupOrColumnMeta,
+    categories: Sequence[str] | None = None,
+    colors: Dict[str, Any] | None = None,
+) -> GroupOrColumnMeta:
     """Produce a categorical copy of ``base_meta`` for the synthetic ``question`` column.
 
     ``continuous`` and ``ordered`` are cleared so question identity is nominal, not inherited from the group.
@@ -30,6 +28,8 @@ def _question_meta_clone(base_meta: GroupOrColumnMeta, categories: Sequence[str]
     clone.ordered = False
     if categories is not None:
         clone.categories = list(categories)
+    if colors:
+        clone.colors = colors
     return clone
 
 
@@ -93,11 +93,6 @@ def _normalize_color_dict(scale: Mapping[str, Color | str] | None) -> Dict[str, 
 
 # Type alias for all Altair chart types that plot functions may return
 AltairChart = alt.Chart | alt.LayerChart | alt.FacetChart | alt.VConcatChart | alt.HConcatChart | alt.ConcatChart
-
-
-# --------------------------------------------------------
-#          SHARED UTILITY FUNCTIONS
-# --------------------------------------------------------
 
 
 def _get_cat_num_vals(

--- a/salk_toolkit/pp/filters.py
+++ b/salk_toolkit/pp/filters.py
@@ -99,18 +99,20 @@ def _pp_filter_data_lz(
             else:
                 flst = [v]  # Just filter on single value
 
-        col_expr = pl.col(k)
+        values = list(flst) if isinstance(flst, (list, tuple)) else [flst]
         dtype = schema.get(k) if k in schema else None
-        if dtype == pl.Categorical or dtype == pl.Enum:
-            col_expr = col_expr.cast(pl.Utf8)
-        values = flst if isinstance(flst, (list, tuple)) else [flst]
-        value_expr = None
-        for val in values:
-            cond = col_expr == val
-            value_expr = cond if value_expr is None else (value_expr | cond)
-        if value_expr is None:
+        if isinstance(dtype, pl.Enum):
+            # is_in raises on values outside the enum vocabulary; those can never match anyway
+            vocab = set(dtype.categories.to_list())
+            values = [v for v in values if v in vocab]
+            if not values:
+                inds &= pl.lit(False)
+                continue
+        if not values:
             continue
-        inds &= value_expr & ~col_expr.is_null()
+        # is_in never matches nulls, works directly on Categorical (string cache is enabled
+        # by pp_transform_data), and pushes down to the scan unlike an OR-chain of casts
+        inds &= pl.col(k).is_in(values)
 
     filtered_df = df.filter(inds)
 
@@ -129,7 +131,7 @@ def _pp_filter_data(
     return ldf.collect().to_pandas()
 
 
-def _pl_quantiles(ldf: pl.LazyFrame, cname: str, qs: Sequence[float]) -> np.ndarray:
+def _pl_quantiles(ldf: pl.LazyFrame, cname: str, qs: Sequence[float] | np.ndarray) -> np.ndarray:
     """Efficient way to calculate multiple quantiles at once with polars in one pass."""
 
     return ldf.select([pl.col(cname).quantile(q).alias(str(q)) for q in qs]).collect().to_numpy()[0]

--- a/salk_toolkit/pp/matching.py
+++ b/salk_toolkit/pp/matching.py
@@ -26,19 +26,6 @@ priority_weights = {
     "required_meta": [n_a, 500],
 }
 
-# More agressive old version:
-# priority_weights = {
-#     'draws': [n_a, 50],
-#     'nonnegative': [n_a, 50],
-#     'hidden': [n_a, 0],
-
-#     'ordered': [n_a, 100],
-#     'likert': [n_a, 200],
-#     'required_meta': [n_a, 500],
-# }
-
-# Method for choosing a sensible default plot based on the data and plot metadata
-
 
 def _calculate_priority(plot_meta: PlotMeta, match: Mapping[str, Any]) -> tuple[int, List[str]]:
     """Score how well a plot definition matches the requested descriptor."""

--- a/salk_toolkit/pp/matching.py
+++ b/salk_toolkit/pp/matching.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, Mapping, cast, overload
+from typing import Any, Dict, List, Literal, Mapping, overload
 
 import pandas as pd
 import polars as pl
 
-from salk_toolkit.io import extract_column_meta
 from salk_toolkit.validation import DataMeta, GroupOrColumnMeta, PlotDescriptor, soft_validate
 
 from .common import _get_cat_num_vals
-from .meta import _update_data_meta_with_pp_desc
-from .registry import PlotMeta, get_plot_meta, registry
+from .meta import _extract_column_meta_cached, _update_data_meta_with_pp_desc
+from .registry import PlotMeta, _ensure_plot_registry_loaded, get_plot_meta, registry, registry_meta
 
 
 # First is weight if not matching, second if match
@@ -140,7 +139,7 @@ def matching_plots(
     pp_desc = soft_validate(pp_desc, PlotDescriptor)
 
     if impute:
-        factor_cols = impute_factor_cols(pp_desc, extract_column_meta(data_meta), get_plot_meta(pp_desc.plot))
+        factor_cols = impute_factor_cols(pp_desc, _extract_column_meta_cached(data_meta), get_plot_meta(pp_desc.plot))
         pp_desc = pp_desc.model_copy(update={"factor_cols": factor_cols})
 
     col_meta, _ = _update_data_meta_with_pp_desc(data_meta, pp_desc)
@@ -148,8 +147,7 @@ def matching_plots(
     rc = pp_desc.res_col
     rcm = col_meta[rc]
 
-    lazy = isinstance(df, pl.LazyFrame)
-    if lazy:
+    if isinstance(df, pl.LazyFrame):
         df_cols = df.collect_schema().names()
     else:
         df_cols = df.columns
@@ -163,12 +161,11 @@ def matching_plots(
     if rcm.categories is not None:
         nonneg = True
     else:
-        if not lazy:
-            min_val = df[cols].min(axis=None)
-        else:
-            # Casting with strict=False makes this robust even if some columns are non-numeric.
-            min_val = df.select(pl.min_horizontal(pl.col(cols).cast(pl.Float64, strict=False).min())).collect().item()
-        nonneg = cast(float, min_val) >= 0
+        # Answered from metadata only: scanning the data would cost a full pass over all
+        # res columns on every plot render. Unknown counts as not non-negative, which only
+        # lowers the ranking of nonnegative-preferring plots on unannotated data.
+        val_range = rcm.val_range
+        nonneg = val_range is not None and val_range[0] is not None and val_range[0] >= 0
 
     convert_res = pp_desc.convert_res
     if convert_res == "continuous" and (rcm.categories is not None):
@@ -195,7 +192,10 @@ def matching_plots(
         "facet_metas": facet_metas,
     }
 
-    res = [(pn, *_calculate_priority(get_plot_meta(pn), match)) for pn in registry.keys()]
+    # _calculate_priority only reads the meta, so pass the registry entry directly
+    # rather than a deep copy per plot (get_plot_meta deep-copies defensively).
+    _ensure_plot_registry_loaded()
+    res = [(pn, *_calculate_priority(registry_meta[pn], match)) for pn in registry.keys()]
     if details:
         return {n: (p, i) for (n, p, i) in res}  # Return dict with priorities and failure reasons
     else:

--- a/salk_toolkit/pp/meta.py
+++ b/salk_toolkit/pp/meta.py
@@ -6,7 +6,8 @@ from typing import Dict, List
 
 from pydantic import BaseModel
 
-from salk_toolkit.io import extract_column_meta, group_columns_dict
+from salk_toolkit.io import extract_column_meta
+from salk_toolkit.io import group_columns_dict
 from salk_toolkit.validation import (
     BlockScaleMeta,
     ColumnBlockMeta,
@@ -15,6 +16,24 @@ from salk_toolkit.validation import (
     PlotDescriptor,
     soft_validate,
 )
+
+
+# extract_column_meta runs a pydantic validation per column, which is a real per-plot cost
+# on datasets with hundreds of columns - and it gets called several times per plot render.
+# Cache per meta instance; keys hold a strong reference so id() stays valid while cached.
+_col_meta_cache: Dict[int, tuple[DataMeta, Dict[str, GroupOrColumnMeta]]] = {}
+
+
+def _extract_column_meta_cached(data_meta: DataMeta) -> Dict[str, GroupOrColumnMeta]:
+    """Cached ``extract_column_meta``; returns a fresh dict so callers can replace entries."""
+
+    key = id(data_meta)
+    hit = _col_meta_cache.get(key)
+    if hit is None or hit[0] is not data_meta:
+        if len(_col_meta_cache) > 8:
+            _col_meta_cache.clear()
+        _col_meta_cache[key] = (data_meta, extract_column_meta(data_meta))
+    return dict(_col_meta_cache[key][1])
 
 
 def _update_data_meta_with_pp_desc(
@@ -43,7 +62,7 @@ def _update_data_meta_with_pp_desc(
 
         if res_meta.scale is None and res_meta.columns:
             base_col_name = next(iter(res_meta.columns.keys()), None)
-            base_col_meta = extract_column_meta(data_meta).get(base_col_name)
+            base_col_meta = _extract_column_meta_cached(meta_obj).get(base_col_name) if base_col_name else None
             if base_col_meta is not None:
                 scale_payload = base_col_meta.model_dump(mode="python")
                 scale_payload["col_prefix"] = ""
@@ -52,7 +71,7 @@ def _update_data_meta_with_pp_desc(
         structure[res_meta.name] = res_meta
         working_meta = working_meta.model_copy(update={"structure": structure})
 
-    col_meta = extract_column_meta(working_meta)
+    col_meta = _extract_column_meta_cached(working_meta)
     gc_dict = group_columns_dict(working_meta)
 
     col_meta_override = desc_obj.col_meta or {}

--- a/salk_toolkit/pp/plotting.py
+++ b/salk_toolkit/pp/plotting.py
@@ -26,7 +26,7 @@ from .common import (
 )
 from .matching import _inner_outer_factors, impute_factor_cols, matching_plots
 from .meta import _extract_column_meta_cached
-from .registry import PlotMeta, _get_plot_fn, _stk_deregister, get_plot_meta, stk_plot
+from .registry import PlotMeta, _stk_deregister, get_plot_fn, get_plot_meta, stk_plot
 from .wrangle import pp_transform_data
 
 
@@ -349,7 +349,7 @@ def create_plot(
     if dry_run:
         return pi
 
-    plot_fn = _get_plot_fn(pp_desc.plot)
+    plot_fn = get_plot_fn(pp_desc.plot)
     if alt_wrapper is None:
         alt_wrapper = lambda p: p
 

--- a/salk_toolkit/pp/plotting.py
+++ b/salk_toolkit/pp/plotting.py
@@ -21,7 +21,6 @@ from .common import (
     FacetMeta,
     PlotInput,
     _get_cat_num_vals,
-    _meta_to_plain,
     _normalize_color_dict,
     special_columns,
 )
@@ -250,7 +249,7 @@ def create_plot(
                 if v == "pass":
                     facet_meta = col_meta.get(pi.facets[i].ocol)
                     if facet_meta:
-                        plot_args[k] = _meta_to_plain(facet_meta).get(k)
+                        plot_args[k] = facet_meta.model_dump(mode="python").get(k)
 
         factor_cols = factor_cols[n_inner:]  # Leave rest for external faceting
     pi.outer_factors = factor_cols
@@ -386,51 +385,19 @@ def create_plot(
                 )
             ]
         else:  # Use faceting
+
+            def _fdef(field: str) -> Dict[str, Any]:
+                return {"field": field, "type": "ordinal", "sort": utils.get_categories(data[field].dtype)}
+
+            row = alt.Row(**_fdef(pi.outer_factors[0]), header=alt.Header(labelOrient="top"))
+            base = _call_plot_fn().properties(**dims, **alt_properties)
             if n_facet_cols == 1:
-                plot = alt_wrapper(
-                    _call_plot_fn()
-                    .properties(**dims, **alt_properties)
-                    .facet(
-                        row=alt.Row(
-                            field=pi.outer_factors[0],
-                            type="ordinal",
-                            sort=utils.get_categories(data[pi.outer_factors[0]].dtype),
-                            header=alt.Header(labelOrient="top"),
-                        )
-                    )
-                )
+                plot = base.facet(row=row)
             elif len(pi.outer_factors) > 1:
-                plot = alt_wrapper(
-                    _call_plot_fn()
-                    .properties(**dims, **alt_properties)
-                    .facet(
-                        column=alt.Column(
-                            field=pi.outer_factors[1],
-                            type="ordinal",
-                            sort=utils.get_categories(data[pi.outer_factors[1]].dtype),
-                        ),
-                        row=alt.Row(
-                            field=pi.outer_factors[0],
-                            type="ordinal",
-                            sort=utils.get_categories(data[pi.outer_factors[0]].dtype),
-                            header=alt.Header(labelOrient="top"),
-                        ),
-                    )
-                )
+                plot = base.facet(column=alt.Column(**_fdef(pi.outer_factors[1])), row=row)
             else:  # n_facet_cols!=1 but just one facet
-                plot = alt_wrapper(
-                    _call_plot_fn()
-                    .properties(**dims, **alt_properties)
-                    .facet(
-                        alt.Facet(
-                            field=pi.outer_factors[0],
-                            type="ordinal",
-                            sort=utils.get_categories(data[pi.outer_factors[0]].dtype),
-                        ),
-                        columns=n_facet_cols,
-                    )
-                )
-            plot = plot.configure_view(discreteHeight={"step": 20})
+                plot = base.facet(alt.Facet(**_fdef(pi.outer_factors[0])), columns=n_facet_cols)
+            plot = alt_wrapper(plot).configure_view(discreteHeight={"step": 20})
     else:
         plot = alt_wrapper(
             _call_plot_fn().properties(**dims, **alt_properties).configure_view(discreteHeight={"step": 20})

--- a/salk_toolkit/pp/plotting.py
+++ b/salk_toolkit/pp/plotting.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import itertools as it
 import json
-from copy import copy as shallow_copy, deepcopy
-from typing import Any, Callable, Dict, List, Mapping, MutableMapping, cast
+from copy import copy as shallow_copy
+from typing import Any, Callable, Dict, List, Mapping, MutableMapping, Tuple, cast
 
 import altair as alt
 import pandas as pd
 import polars as pl
 
 import salk_toolkit.utils as utils
-from salk_toolkit.io import extract_column_meta, read_parquet_with_metadata
+from salk_toolkit.io import read_parquet_with_metadata
 from salk_toolkit.utils import batch, clean_kwargs
 from salk_toolkit.validation import ColumnMeta, DataMeta, GroupOrColumnMeta, PlotDescriptor, soft_validate
 
@@ -26,6 +26,7 @@ from .common import (
     special_columns,
 )
 from .matching import _inner_outer_factors, impute_factor_cols, matching_plots
+from .meta import _extract_column_meta_cached
 from .registry import PlotMeta, _get_plot_fn, _stk_deregister, get_plot_meta, stk_plot
 from .wrangle import pp_transform_data
 
@@ -51,7 +52,7 @@ def _meta_color_scale(
     cats = utils.get_categories(column.dtype) if column is not None and column.dtype.name == "category" else None
     if scale is None and column is not None and column.dtype.name == "category" and utils.get_ordered(column.dtype):
         # Split the values into negative, neutral, positive
-        neg, neut, pos = utils.split_to_neg_neutral_pos(cats, neutrals)
+        neg, neut, pos = utils.split_to_neg_neutral_pos(cats or [], neutrals)
 
         # Create a color scale for each category and combine them
         bidir_mid = len(utils.default_bidirectional_gradient) // 2
@@ -140,6 +141,11 @@ def _create_tooltip(
         tooltips.append(t)
 
     return tooltips, data
+
+
+# --------------------------------------------------------
+#          PLOTTING PART OF THE PIPELINE
+# --------------------------------------------------------
 
 
 def create_plot(
@@ -255,7 +261,7 @@ def create_plot(
     pi.value_range = tuple(data[pi.value_col].agg(["min", "max"]))
 
     pi.outer_colors = (
-        _normalize_color_dict(col_meta.get(pi.outer_factors[0], GroupOrColumnMeta()).colors or {})
+        _normalize_color_dict(col_meta.get(pi.outer_factors[0], GroupOrColumnMeta()).colors or {}) or {}
         if pi.outer_factors
         else {}
     )
@@ -356,10 +362,8 @@ def create_plot(
 
     def _call_plot_fn(
         data_override: pd.DataFrame | None = None,
-    ) -> AltairChart | List[List[AltairChart]] | PlotInput:
-        payload = pi if data_override is None else deepcopy(pi)
-        if data_override is not None:
-            payload.data = data_override
+    ) -> AltairChart:
+        payload = pi if data_override is None else pi.model_copy(update={"data": data_override})
         return plot_fn(payload, **plot_arg_payload)
 
     if plot_meta.as_is:  # if as_is set, just return the plot as-is
@@ -444,7 +448,7 @@ publish_spec = {"config": {"legend": {"labelLimit": 0}, "axis": {"labelLimit": 0
 
 def _apply_publish_mode(plot: AltairChart) -> AltairChart:
     """Apply publish mode to the plot."""
-    spec = utils.recursive_dict_merge(plot.to_dict(), publish_spec)
+    spec = cast(Dict[str, Any], utils.recursive_dict_merge(plot.to_dict(), publish_spec))
     return type(plot).from_dict(spec)
 
 
@@ -486,11 +490,12 @@ def e2e_plot(
         raise ValueError(f"Parquet file {data_file} has no data metadata")
 
     if impute:
-        factor_cols = impute_factor_cols(pp_desc, extract_column_meta(data_meta), get_plot_meta(pp_desc.plot))
+        factor_cols = impute_factor_cols(pp_desc, _extract_column_meta_cached(data_meta), get_plot_meta(pp_desc.plot))
         pp_desc = pp_desc.model_copy(update={"factor_cols": factor_cols})
 
     if check_match:
-        matches = matching_plots(pp_desc, full_df, data_meta, details=True, list_hidden=True)
+        # If we imputed above, the descriptor already has final factor_cols - skip re-imputing
+        matches = matching_plots(pp_desc, full_df, data_meta, details=True, list_hidden=True, impute=not impute)
         if isinstance(matches, list) or pp_desc.plot not in matches:
             raise Exception(f"Plot not registered: {pp_desc.plot}")
 
@@ -501,11 +506,12 @@ def e2e_plot(
 
     if plot_cache is not None:
         key = json.dumps(pp_desc.model_dump(mode="python"), sort_keys=True)
-        if key in plot_cache:
-            pi = deepcopy(plot_cache[key])
-        else:
-            pi = pp_transform_data(full_df, data_meta, pp_desc)
-            plot_cache[key] = deepcopy(pi)
+        if key not in plot_cache:
+            plot_cache[key] = pp_transform_data(full_df, data_meta, pp_desc)
+        cached = plot_cache[key]
+        # Shallow copies protect the cache: create_plot copies pi.data before mutating and
+        # col_meta values are replaced (never mutated in place), so no deepcopy is needed
+        pi = cached.model_copy(update={"data": cached.data.copy(), "col_meta": dict(cached.col_meta)})
     else:  # No caching
         pi = pp_transform_data(full_df, data_meta, pp_desc)
 
@@ -517,6 +523,11 @@ def e2e_plot(
 
 
 # Another convenience function to simplify testing new plots
+
+
+# --------------------------------------------------------
+#          TESTING
+# --------------------------------------------------------
 
 
 def test_new_plot(
@@ -540,6 +551,6 @@ def test_new_plot(
     stk_plot(**{**meta_payload, "plot_name": "test"})(fn)  # Register the plot under name 'test'
     try:
         pp_desc = pp_desc.model_copy(update={"plot": "test"})
-        return e2e_plot(pp_desc, *args, **kwargs)
+        return e2e_plot(pp_desc, *cast(Tuple[Any, ...], args), **cast(Dict[str, Any], kwargs))
     finally:
         _stk_deregister("test")  # And de-register it again

--- a/salk_toolkit/pp/registry.py
+++ b/salk_toolkit/pp/registry.py
@@ -24,6 +24,9 @@ class PlotMeta(PBase):
     requires_factor: bool = False
     no_question_facet: bool = False
     agg_fn: Optional[str] = None
+    # Cap on filtered rows, applied before group questions are melted (keeps raw plots at
+    # sample_n x n_questions rows). pp_desc.sample and plot_args["sample_size"] override it.
+    sample: Optional[int] = None
     group_sizes: bool = False
     sort_numeric_first_facet: bool = False
     no_faceting: bool = False

--- a/salk_toolkit/pp/registry.py
+++ b/salk_toolkit/pp/registry.py
@@ -13,6 +13,11 @@ from salk_toolkit.validation import DF, ColumnMeta, GroupOrColumnMeta, PBase, so
 from .common import AltairChart, FacetMeta, PlotInput
 
 
+# --------------------------------------------------------
+#          PLOT REGISTRY FUNCTIONS
+# --------------------------------------------------------
+
+
 class PlotMeta(PBase):
     """Metadata registered for each plot function via ``@stk_plot``."""
 
@@ -180,12 +185,12 @@ def get_plot_fn(plot_name: str) -> Callable[..., AltairChart]:
             cat_col=cast(Optional[str], pparams.get("cat_col")),
             val_format=cast(str, pparams.get("val_format") or "%"),
             val_range=cast(Optional[Tuple[Optional[float], Optional[float]]], pparams.get("val_range")),
-            filtered_size=float(cast(object, pparams.get("filtered_size") or 0.0)),
+            filtered_size=float(cast(Any, pparams.get("filtered_size") or 0.0)),
             facets=facets_list,
             tooltip=cast(List[Any], pparams.get("tooltip") or []),
             value_range=cast(Optional[Tuple[float, float]], pparams.get("value_range")),
             outer_colors=cast(Dict[str, Any], pparams.get("outer_colors") or {}),
-            width=int(cast(object, pparams.get("width") or 800)),
+            width=int(cast(Any, pparams.get("width") or 800)),
             alt_properties=cast(Dict[str, Any], pparams.get("alt_properties") or {}),
             outer_factors=cast(List[str], pparams.get("outer_factors") or []),
             plot_args=cast(Dict[str, Any], pparams.get("plot_args") or {}),

--- a/salk_toolkit/pp/registry.py
+++ b/salk_toolkit/pp/registry.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, cast
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, cast
 
-import pandas as pd
 
 import salk_toolkit.utils as utils
-from salk_toolkit.validation import DF, ColumnMeta, GroupOrColumnMeta, PBase, soft_validate
+from salk_toolkit.validation import DF, PBase
 
-from .common import AltairChart, FacetMeta, PlotInput
+from .common import AltairChart
 
 
 class PlotMeta(PBase):
@@ -101,95 +100,15 @@ def _stk_deregister(plot_name: str) -> None:
     del registry_meta[plot_name]
 
 
-def _get_plot_fn(plot_name: str) -> Callable[..., Any]:
-    """Retrieve a registered plot function by name."""
+def get_plot_fn(plot_name: str) -> Callable[..., AltairChart]:
+    """Return the registered plot function.
+
+    Plot functions take a ``PlotInput`` as their first argument, followed by
+    plot-specific keyword arguments, e.g. ``get_plot_fn("matrix")(pi, log_colors=True)``.
+    """
 
     _ensure_plot_registry_loaded()
     return registry[plot_name]
-
-
-# External legacy plot builder callable for Streamlit tools.
-def get_plot_fn(plot_name: str) -> Callable[..., AltairChart]:
-    """Return a legacy plot builder callable for Streamlit tools.
-
-    Historically, `salk_internal_package` tools called `stk` plots directly via:
-    `get_plot_fn("matrix")(**pparams)`, where `pparams` was a dict containing
-    keys like `data`, `facets`, and `value_col`.
-
-    The plot pipeline was refactored to pass a `PlotInput` object into plot
-    functions instead. This helper restores the old calling convention by
-    wrapping the registered plot function.
-
-    Args:
-        plot_name: Registry name of the plot to retrieve (e.g. "matrix", "density").
-
-    Returns:
-        Callable that accepts legacy `pparams` keyword arguments and returns an Altair chart.
-    """
-
-    plot_fn = _get_plot_fn(plot_name)
-    sig = inspect.signature(plot_fn)
-    params = list(sig.parameters.keys())
-    first_param = params[0] if params else None
-    plot_param_names = {p for p in params if p != first_param}
-
-    def _facet(raw: object) -> FacetMeta:
-        if isinstance(raw, FacetMeta):
-            return raw
-        if not isinstance(raw, dict):
-            raise TypeError("Facet definitions must be dicts or FacetMeta instances")
-        col = raw.get("col")
-        if not isinstance(col, str) or not col:
-            raise ValueError("Facet dict must contain non-empty 'col'")
-        meta_raw = raw.get("meta")
-        return FacetMeta(
-            col=col,
-            ocol=cast(str, raw.get("ocol", col)),
-            order=[str(x) for x in cast(Sequence[Any], raw.get("order", []))],
-            colors=raw.get("colors"),
-            neutrals=[str(x) for x in cast(Sequence[Any], raw.get("neutrals", []))],
-            meta=soft_validate(meta_raw, ColumnMeta) if meta_raw is not None else ColumnMeta(),
-        )
-
-    def _legacy_callable(**pparams: object) -> AltairChart:
-        # Split PlotInput-ish keys vs plot-function kwargs.
-        plot_kwargs = {k: v for k, v in dict(pparams).items() if k in plot_param_names}
-
-        data = pparams.get("data")
-        if data is None:
-            raise ValueError("Legacy plot call requires 'data'")
-        if not isinstance(data, pd.DataFrame):
-            data = pd.DataFrame(data)  # type: ignore[arg-type]
-
-        facets_raw = pparams.get("facets", [])
-        facets_list = [_facet(f) for f in cast(Sequence[Any], facets_raw)] if facets_raw else []
-
-        value_col = pparams.get("value_col")
-        if not isinstance(value_col, str) or not value_col:
-            raise ValueError("Legacy plot call requires non-empty 'value_col'")
-
-        # pyright: ignore[reportCallIssue] - legacy dict-based API intentionally coerces loosely typed inputs.
-        pi = PlotInput(  # type: ignore[call-arg]
-            data=data,
-            col_meta=cast(Dict[str, GroupOrColumnMeta], pparams.get("col_meta") or {}),
-            value_col=value_col,
-            cat_col=cast(Optional[str], pparams.get("cat_col")),
-            val_format=cast(str, pparams.get("val_format") or "%"),
-            val_range=cast(Optional[Tuple[Optional[float], Optional[float]]], pparams.get("val_range")),
-            filtered_size=float(cast(Any, pparams.get("filtered_size") or 0.0)),
-            facets=facets_list,
-            tooltip=cast(List[Any], pparams.get("tooltip") or []),
-            value_range=cast(Optional[Tuple[float, float]], pparams.get("value_range")),
-            outer_colors=cast(Dict[str, Any], pparams.get("outer_colors") or {}),
-            width=int(cast(Any, pparams.get("width") or 800)),
-            alt_properties=cast(Dict[str, Any], pparams.get("alt_properties") or {}),
-            outer_factors=cast(List[str], pparams.get("outer_factors") or []),
-            plot_args=cast(Dict[str, Any], pparams.get("plot_args") or {}),
-        )
-
-        return cast(AltairChart, plot_fn(pi, **plot_kwargs))
-
-    return _legacy_callable
 
 
 def get_plot_meta(plot_name: str) -> PlotMeta | None:

--- a/salk_toolkit/pp/registry.py
+++ b/salk_toolkit/pp/registry.py
@@ -13,11 +13,6 @@ from salk_toolkit.validation import DF, ColumnMeta, GroupOrColumnMeta, PBase, so
 from .common import AltairChart, FacetMeta, PlotInput
 
 
-# --------------------------------------------------------
-#          PLOT REGISTRY FUNCTIONS
-# --------------------------------------------------------
-
-
 class PlotMeta(PBase):
     """Metadata registered for each plot function via ``@stk_plot``."""
 
@@ -30,7 +25,6 @@ class PlotMeta(PBase):
     requires_factor: bool = False
     no_question_facet: bool = False
     agg_fn: Optional[str] = None
-    sample: Optional[int] = None
     group_sizes: bool = False
     sort_numeric_first_facet: bool = False
     no_faceting: bool = False
@@ -47,8 +41,6 @@ class PlotMeta(PBase):
 registry: Dict[str, Callable[..., Any]] = {}
 registry_meta: Dict[str, PlotMeta] = {}
 _registry_bootstrapped = False
-
-stk_plot_defaults = {"data_format": "longform"}
 
 
 def _ensure_plot_registry_loaded() -> None:
@@ -95,8 +87,7 @@ def stk_plot(plot_name: str, **r_kwargs: object) -> Callable[[Callable[..., obje
     def _decorator(gfunc: Callable[..., object]) -> Callable[..., object]:
         _ensure_plot_args_sync(gfunc, r_kwargs)
         registry[plot_name] = gfunc
-        meta_payload = {"name": plot_name, **stk_plot_defaults, **r_kwargs}
-        registry_meta[plot_name] = PlotMeta.model_validate(meta_payload)
+        registry_meta[plot_name] = PlotMeta.model_validate({"name": plot_name, **r_kwargs})
 
         return gfunc
 
@@ -208,10 +199,3 @@ def get_plot_meta(plot_name: str) -> PlotMeta | None:
     if plot_name not in registry_meta:
         return None
     return registry_meta[plot_name].model_copy(deep=True)
-
-
-def _get_all_plots() -> List[str]:
-    """List registered plot names in alphabetical order."""
-
-    _ensure_plot_registry_loaded()
-    return sorted(list(registry.keys()))

--- a/salk_toolkit/pp/wrangle.py
+++ b/salk_toolkit/pp/wrangle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import cache
 from typing import Any, Dict, List, MutableMapping, Sequence
 
 import numpy as np
@@ -47,7 +48,7 @@ def pp_transform_data(
 
     # Figure out which columns we actually need
     weight_col = data_meta.weight_col or "row_weights"
-    factor_cols = list(pp_desc.factor_cols).copy()
+    factor_cols = list(pp_desc.factor_cols)
 
     # Ensure weight column is present (fill with 1.0 if not)
     if weight_col not in all_col_names:
@@ -56,7 +57,7 @@ def pp_transform_data(
     else:
         full_df = full_df.with_columns(pl.col(weight_col).fill_null(1.0))
 
-    # For transforming purposest, res_col is not a factor.
+    # For transforming purposes, res_col is not a factor.
     # It will be made one for categorical plots for plotting part, but for pp_transform_data, remove it
     if pp_desc.res_col in factor_cols:
         factor_cols.remove(pp_desc.res_col)
@@ -65,10 +66,10 @@ def pp_transform_data(
     cols = [pp_desc.res_col] + factor_cols + list(pp_desc.filter.keys() if pp_desc.filter else [])
     cols += [c for c in extra_cols if c in all_col_names and c not in cols]
 
-    # If any aliases are used, cconvert them to column names according to the data_meta
+    # If any aliases are used, convert them to column names according to the data_meta
     cols = [c for c in np.unique(list_aliases(cols, gc_dict)) if c in all_col_names]
 
-    # Remove draws_data if calcualted_draws is disabled
+    # Remove draws_data if calculated_draws is disabled
     draws_data = data_meta.draws_data or {}
     if not pp_desc.calculated_draws:
         draws_data = {}
@@ -88,26 +89,21 @@ def pp_transform_data(
     if need_id:
         # Add row id-s before filtering so draw indices line up with the original rows.
         full_df = full_df.with_row_index("id")
+        cols += ["id"]
 
     # The total row count is only needed to build draws. Compute it lazily (and once)
     # off this pre-filter snapshot so the common no-draws path avoids a full scan.
     counting_df = full_df
-    total_n_cached: int | None = None
-
-    def get_total_n() -> int:
-        nonlocal total_n_cached
-        if total_n_cached is None:
-            total_n_cached = int(counting_df.select(pl.len()).collect().item())
-        return total_n_cached
+    get_total_n = cache(lambda: int(counting_df.select(pl.len()).collect().item()))
 
     # For more customized filtering in dashboards
     # Has to be done before downselecting to only needed columns
     if pp_desc.pl_filter:
         full_df = full_df.filter(eval(pp_desc.pl_filter, {"pl": pl}))
 
-    if need_id:
-        cols += ["id"]
     df = full_df.select(cols)  # Select only the columns we need
+
+    res_cols = gc_dict.get(pp_desc.res_col, [pp_desc.res_col])
 
     # Filter the data with given filters
     if pp_desc.filter:
@@ -115,7 +111,6 @@ def pp_transform_data(
 
         # Project away columns that were only needed to compute the filter, so they don't
         # ride through the unpivot (which multiplies every carried column by n_questions)
-        res_cols = gc_dict.get(pp_desc.res_col, [pp_desc.res_col])
         needed = set(res_cols) | set(factor_cols) | set(base_cols) | {weight_col, "draw", "id"}
         keep = [c for c in cols if c in needed]
         if keep != cols:
@@ -145,8 +140,7 @@ def pp_transform_data(
     original_question_colors = original_question_meta.question_colors
 
     # Convert ordered categorical to continuous if we can
-    rcl = gc_dict.get(pp_desc.res_col, [pp_desc.res_col])
-    rcl = [c for c in rcl if c in cols]
+    rcl = [c for c in res_cols if c in cols]
     for rc in rcl:
         res_meta = c_meta[rc]
         if pp_desc.convert_res == "continuous":
@@ -219,10 +213,7 @@ def pp_transform_data(
         id_vars = [c for c in cols if (c not in value_vars or c in factor_cols)]
         prefix = original_question_meta.col_prefix or ""
         categories = [v.removeprefix(prefix) for v in value_vars]
-        question_meta = _question_meta_clone(original_question_meta, categories)
-        if original_question_colors:
-            question_meta.colors = original_question_colors
-        c_meta["question"] = question_meta
+        c_meta["question"] = _question_meta_clone(original_question_meta, categories, original_question_colors)
 
         draw_dfs: List[pl.DataFrame] = []
         if "draw" in cols and draws_data:
@@ -287,10 +278,9 @@ def pp_transform_data(
         n_questions = 1
         if "question" in factor_cols:
             filtered_df = filtered_df.with_columns(pl.lit(pp_desc.res_col).alias("question").cast(pl.Categorical))
-            question_meta = _question_meta_clone(original_question_meta, categories=[pp_desc.res_col])
-            if original_question_colors:
-                question_meta.colors = original_question_colors
-            c_meta["question"] = question_meta
+            c_meta["question"] = _question_meta_clone(
+                original_question_meta, [pp_desc.res_col], original_question_colors
+            )
 
     # Aggregate the data into right shape
     pi = _wrangle_data(filtered_df, c_meta, factor_cols, weight_col, pp_desc, n_questions, wide_value_vars)
@@ -334,8 +324,6 @@ def _wrangle_data(
     draws = plot_meta.draws
     data_format = plot_meta.data_format
 
-    # if pp_desc['res_col'] in factor_cols: factor_cols.remove(pp_desc['res_col']) # Res cannot also be a factor
-
     # Determine the groupby dimensions
     gb_dims = factor_cols + (["draw"] if draws else []) + (["id"] if plot_meta.data_format == "raw" else [])
 
@@ -349,16 +337,7 @@ def _wrangle_data(
 
     if data_format == "raw":
         value_col = res_col
-        if plot_meta.sample:
-            selected = raw_df.select(gb_dims + [res_col])
-            grouped = getattr(selected, "groupby", lambda *args: selected)(gb_dims)
-            sample_method = getattr(grouped, "sample", None)
-            if sample_method is not None:
-                data = sample_method(n=plot_meta.sample, with_replacement=True)
-            else:
-                data = grouped
-        else:
-            data = raw_df.select(gb_dims + [res_col])
+        data = raw_df.select(gb_dims + [res_col])
 
     elif data_format == "longform":
         agg_fn = pp_desc.agg_fn or "mean"
@@ -385,9 +364,6 @@ def _wrangle_data(
                 ]
                 data = pl.concat(parts)
                 data = data.with_columns(pl.col("percent").sum().over(gb + ["question"]).alias(weight_col))
-                if agg_fn == "mean":
-                    data = data.with_columns(pl.col("percent") / pl.col(weight_col))
-                # agg_fn is restricted to mean/sum by the wide-path guard
 
             else:  # Continuous: aggregate each question column per group
                 value_col = res_col
@@ -399,15 +375,15 @@ def _wrangle_data(
                 data = data.unpivot(
                     variable_name="question", value_name=res_col, index=gb + [weight_col], on=wide_value_vars
                 )
-                if agg_fn == "mean":
-                    data = data.with_columns(pl.col(res_col) / pl.col(weight_col))
 
+            # Wide-path guard restricts categorical groups to mean/sum, so this covers both branches
+            if agg_fn == "mean":
+                data = data.with_columns(pl.col(value_col) / pl.col(weight_col))
             data = data.with_columns(pl.col("question").cast(pl.Enum(wide_value_vars)))
             if gb == ["dummy_col"]:
                 data = data.drop("dummy_col")
 
-        # Check if categorical by looking at schema
-        elif isinstance(schema[res_col], (pl.Categorical, pl.Enum, pl.String)):
+        elif isinstance(schema[res_col], (pl.Categorical, pl.Enum, pl.String)):  # Categorical
             cat_col = res_col
             value_col = "percent"
 
@@ -434,7 +410,7 @@ def _wrangle_data(
                     .agg(pl.col([res_col, weight_col]).sum())
                 )
                 if agg_fn == "mean":
-                    data = data.with_columns(pl.col(res_col) / pl.col(weight_col).alias(res_col))
+                    data = data.with_columns(pl.col(res_col) / pl.col(weight_col))
             elif agg_fn == "posneg_mean":
                 # Needs prefix to avoid name conflict while aggregating
                 data = (
@@ -445,10 +421,10 @@ def _wrangle_data(
                         pl.col([res_col, weight_col]).sum(),
                         pl.col(["reverse_" + res_col, weight_col]).sum().name.prefix("reverse_"),
                     )
-                    .select(pl.exclude("reverse_N"))
+                    .select(pl.exclude("reverse_" + weight_col))
                     .rename({"reverse_reverse_" + res_col: "reverse_" + res_col})
-                    .with_columns(pl.col("reverse_" + res_col) / pl.col(weight_col).alias("reverse_" + res_col))
-                    .with_columns(pl.col(res_col) / pl.col(weight_col).alias(res_col))
+                    .with_columns(pl.col("reverse_" + res_col) / pl.col(weight_col))
+                    .with_columns(pl.col(res_col) / pl.col(weight_col))
                     .with_columns((pl.col(res_col) + pl.col("reverse_" + res_col)).alias("ordering_value"))
                 )
             else:  # median, min, max, etc. - ignore weight_col

--- a/salk_toolkit/pp/wrangle.py
+++ b/salk_toolkit/pp/wrangle.py
@@ -74,11 +74,11 @@ def pp_transform_data(
     if not pp_desc.calculated_draws:
         draws_data = {}
 
-    # The sampled ordered-population experiment must cap rows before melting; resolve its
-    # sample size here already because the id-based sampling below needs the row index.
+    # Plots can declare a row cap (plot_meta.sample), applied before group questions are
+    # melted. Resolved here already because the id-based sampling below needs the row index.
     sample_n = pp_desc.sample
-    if sample_n is None and pp_desc.plot == "ordered_population_sampled":
-        sample_n = int((pp_desc.plot_args or {}).get("sample_size", 1000))
+    if sample_n is None and plot_meta.sample:
+        sample_n = int((pp_desc.plot_args or {}).get("sample_size", plot_meta.sample))
         if sample_n <= 0:
             raise ValueError("sample_size must be positive")
 

--- a/salk_toolkit/pp/wrangle.py
+++ b/salk_toolkit/pp/wrangle.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import gc
-from typing import List, MutableMapping, Sequence
+from typing import Any, Dict, List, MutableMapping, Sequence
 
 import numpy as np
 import pandas as pd
@@ -74,21 +73,54 @@ def pp_transform_data(
     if not pp_desc.calculated_draws:
         draws_data = {}
 
-    # Add row id-s and find count - both need to happen before filtering
-    full_df = full_df.with_row_index("id")
-    total_n = full_df.select(pl.len()).collect().item()
+    # The sampled ordered-population experiment must cap rows before melting; resolve its
+    # sample size here already because the id-based sampling below needs the row index.
+    sample_n = pp_desc.sample
+    if sample_n is None and pp_desc.plot == "ordered_population_sampled":
+        sample_n = int((pp_desc.plot_args or {}).get("sample_size", 1000))
+        if sample_n <= 0:
+            raise ValueError("sample_size must be positive")
+
+    # Row id-s are only consumed by the draw joins, sampling, and raw-format grouping.
+    # Adding the index blocks predicate pushdown into the scan (numbering must reflect
+    # pre-filter rows), so skip it entirely when nothing downstream needs it.
+    need_id = plot_meta.data_format == "raw" or ("draw" in cols and bool(draws_data)) or bool(sample_n)
+    if need_id:
+        # Add row id-s before filtering so draw indices line up with the original rows.
+        full_df = full_df.with_row_index("id")
+
+    # The total row count is only needed to build draws. Compute it lazily (and once)
+    # off this pre-filter snapshot so the common no-draws path avoids a full scan.
+    counting_df = full_df
+    total_n_cached: int | None = None
+
+    def get_total_n() -> int:
+        nonlocal total_n_cached
+        if total_n_cached is None:
+            total_n_cached = int(counting_df.select(pl.len()).collect().item())
+        return total_n_cached
 
     # For more customized filtering in dashboards
     # Has to be done before downselecting to only needed columns
     if pp_desc.pl_filter:
         full_df = full_df.filter(eval(pp_desc.pl_filter, {"pl": pl}))
 
-    cols += ["id"]
+    if need_id:
+        cols += ["id"]
     df = full_df.select(cols)  # Select only the columns we need
 
     # Filter the data with given filters
     if pp_desc.filter:
         filtered_df, cols = _pp_filter_data_lz(df, pp_desc.filter, c_meta, gc_dict)
+
+        # Project away columns that were only needed to compute the filter, so they don't
+        # ride through the unpivot (which multiplies every carried column by n_questions)
+        res_cols = gc_dict.get(pp_desc.res_col, [pp_desc.res_col])
+        needed = set(res_cols) | set(factor_cols) | set(base_cols) | {weight_col, "draw", "id"}
+        keep = [c for c in cols if c in needed]
+        if keep != cols:
+            filtered_df = filtered_df.select(keep)
+            cols = keep
     else:
         filtered_df = df
 
@@ -102,13 +134,7 @@ def pp_transform_data(
             )
             c_meta[c] = merge_pydantic_models(c_meta.get(c, GroupOrColumnMeta()), merge_payload)
 
-    # Sample from filtered data. The sampled ordered-population experiment must
-    # cap rows here, before group observations are melted into long form.
-    sample_n = pp_desc.sample
-    if sample_n is None and pp_desc.plot == "ordered_population_sampled":
-        sample_n = int((pp_desc.plot_args or {}).get("sample_size", 1000))
-        if sample_n <= 0:
-            raise ValueError("sample_size must be positive")
+    # Sample from filtered data (sample_n resolved above, before the row index was added)
     if sample_n:
         ids = filtered_df.select("id").collect().get_column("id")
         if len(ids) > sample_n:
@@ -141,20 +167,18 @@ def pp_transform_data(
             )
             nvals = np.array(nvals, dtype="float")  # To handle null as nan
             val_range = (np.nanmin(nvals), np.nanmax(nvals)) if len(nvals) > 0 else (0.0, 1.0)
-            update_model = soft_validate(
-                {
-                    "continuous": True,
-                    "categories": None,
-                    "ordered": False,
-                    "groups": {},
-                    "colors": {},
-                    "num_values": None,
-                    "likert": False,
-                    "neutral_middle": None,
-                    "val_range": val_range,
-                },
-                GroupOrColumnMeta,
-            )
+            update_payload: Dict[str, Any] = {
+                "continuous": True,
+                "categories": None,
+                "ordered": False,
+                "groups": {},
+                "colors": {},
+                "num_values": None,
+                "likert": False,
+                "neutral_middle": None,
+                "val_range": val_range,
+            }
+            update_model = soft_validate(update_payload, GroupOrColumnMeta)
             c_meta[rc] = merge_pydantic_models(c_meta.get(rc, GroupOrColumnMeta()), update_model)
             c_meta[pp_desc.res_col] = merge_pydantic_models(
                 c_meta.get(pp_desc.res_col, GroupOrColumnMeta()), update_model
@@ -183,6 +207,7 @@ def pp_transform_data(
     # Compute draws if needed - Nb: also applies if the draws are shared for the group of questions
     if "draw" in cols and pp_desc.res_col in draws_data:
         uid, ndraws = draws_data[pp_desc.res_col]
+        total_n = get_total_n()
         draws = utils.stable_draws(total_n, ndraws, uid)
         draw_df = pl.DataFrame({"draw": draws, "id": np.arange(0, total_n)})
         filtered_df = filtered_df.drop("draw").join(draw_df.lazy(), on=["id"], how="left")
@@ -199,12 +224,14 @@ def pp_transform_data(
             question_meta.colors = original_question_colors
         c_meta["question"] = question_meta
 
+        draw_dfs: List[pl.DataFrame] = []
         if "draw" in cols and draws_data:
-            draw_dfs, ddf_cache = [], {}
+            ddf_cache = {}
             for c in value_vars:
                 if c in draws_data:
                     uid, ndraws = draws_data[c]
                     if (uid, ndraws) not in ddf_cache:
+                        total_n = get_total_n()
                         draws = utils.stable_draws(total_n, ndraws, uid)
                         ddf_cache[(uid, ndraws)] = pl.DataFrame(
                             {"draw": draws, "question": c, "id": np.arange(0, total_n)}
@@ -218,26 +245,43 @@ def pp_transform_data(
                 filtered_df = filtered_df.drop("draw").join(draw_dfs[0].drop("question").lazy(), on=["id"], how="left")
                 draw_dfs = []  # To avoid adding draws again below
 
-        # Melt i.e. unpivot the questions
-        filtered_df = filtered_df.unpivot(
-            variable_name="question",
-            value_name=pp_desc.res_col,
-            index=id_vars,
-            on=value_vars,
-        )
+        # Continuous longform groups can be aggregated in wide form and unpivoted after,
+        # so the n_rows x n_questions longform frame is never materialized. Requires all
+        # questions to share draws (or have none) and a weight-compatible aggregation.
+        fschema = filtered_df.collect_schema()
+        agg_fn_resolved = plot_meta.agg_fn or pp_desc.agg_fn or "mean"
+        if (
+            plot_meta.data_format == "longform"
+            and "question" in factor_cols
+            and not draw_dfs
+            and agg_fn_resolved != "posneg_mean"
+            and all(not isinstance(fschema[c], (pl.Categorical, pl.Enum, pl.String)) for c in value_vars)
+        ):
+            wide_value_vars = value_vars
+        else:
+            wide_value_vars = None
 
-        # Handle draws for each question
-        if "draw" in cols and draws_data and len(draw_dfs) > 0:
-            filtered_df = (
-                filtered_df.rename({"draw": "old_draw"})
-                .join(pl.concat(draw_dfs).lazy(), on=["id", "question"], how="left")
-                .with_columns(pl.col("draw").fill_null(pl.col("old_draw")))
-                .drop("old_draw")
+            # Melt i.e. unpivot the questions
+            filtered_df = filtered_df.unpivot(
+                variable_name="question",
+                value_name=pp_desc.res_col,
+                index=id_vars,
+                on=value_vars,
             )
 
-        # Convert question to categorical with correct order
-        filtered_df = filtered_df.with_columns(pl.col("question").cast(pl.Enum(value_vars)))
+            # Handle draws for each question
+            if len(draw_dfs) > 0:
+                filtered_df = (
+                    filtered_df.rename({"draw": "old_draw"})
+                    .join(pl.concat(draw_dfs).lazy(), on=["id", "question"], how="left")
+                    .with_columns(pl.col("draw").fill_null(pl.col("old_draw")))
+                    .drop("old_draw")
+                )
+
+            # Convert question to categorical with correct order
+            filtered_df = filtered_df.with_columns(pl.col("question").cast(pl.Enum(value_vars)))
     else:
+        wide_value_vars = None
         n_questions = 1
         if "question" in factor_cols:
             filtered_df = filtered_df.with_columns(pl.lit(pp_desc.res_col).alias("question").cast(pl.Categorical))
@@ -247,7 +291,7 @@ def pp_transform_data(
             c_meta["question"] = question_meta
 
     # Aggregate the data into right shape
-    pi = _wrangle_data(filtered_df, c_meta, factor_cols, weight_col, pp_desc, n_questions)
+    pi = _wrangle_data(filtered_df, c_meta, factor_cols, weight_col, pp_desc, n_questions, wide_value_vars)
 
     pi.val_format = val_format
     pi.val_range = val_range  # Currently not used
@@ -271,8 +315,13 @@ def _wrangle_data(
     weight_col: str,
     pp_desc: PlotDescriptor,
     n_questions: int,
+    wide_value_vars: List[str] | None = None,
 ) -> PlotInput:
-    """Aggregate filtered data into a structured ``PlotInput`` model for create_plot."""
+    """Aggregate filtered data into a structured ``PlotInput`` model for create_plot.
+
+    If ``wide_value_vars`` is given, ``raw_df`` is still in wide form: the question columns
+    are aggregated per group first and only the (small) aggregated frame is unpivoted.
+    """
 
     plot_meta = get_plot_meta(pp_desc.plot)
     assert plot_meta is not None, f"Plot '{pp_desc.plot}' not found in registry"
@@ -293,10 +342,6 @@ def _wrangle_data(
         raw_df = raw_df.with_columns(pl.lit("dummy").alias("dummy_col"))
         gb_dims = ["dummy_col"]
 
-    # if draws and 'draw' in schema.names() and 'augment_to' in pp_desc:
-    #     # Should we try to bootstrap the data to always have augment_to points. Note this is relatively slow
-    #     raw_df = _augment_draws(raw_df,gb_dims[1:],threshold=pp_desc['augment_to'])
-
     value_col = "value"
     cat_col: str | None = None
 
@@ -316,20 +361,38 @@ def _wrangle_data(
     elif data_format == "longform":
         agg_fn = pp_desc.agg_fn or "mean"
         agg_fn = plot_meta.agg_fn or agg_fn
-        # Check if categorical by looking at schema
-        is_categorical = isinstance(schema[res_col], (pl.Categorical, pl.Enum, pl.String))
-        # Check if _highest_lowest_ranked is called before _wrangle_data
 
-        if is_categorical:
+        if wide_value_vars is not None:  # Continuous question group, still in wide form
+            value_col = res_col
+            gb = [d for d in gb_dims if d != "question"]
+            if not gb:
+                raw_df = raw_df.with_columns(pl.lit("dummy").alias("dummy_col"))
+                gb = ["dummy_col"]
+
+            # Aggregate each question column per group, then unpivot the aggregated frame
+            if agg_fn in ["mean", "sum"]:  # Use weighted sum to compute both sum and mean
+                aggs = [(pl.col(q) * pl.col(weight_col)).sum().alias(q) for q in wide_value_vars]
+            else:  # median, min, max, etc. - ignore weight_col
+                aggs = [getattr(pl.col(q), agg_fn)().alias(q) for q in wide_value_vars]
+            data = raw_df.group_by(gb).agg(aggs + [pl.col(weight_col).sum()])
+            data = data.unpivot(
+                variable_name="question", value_name=res_col, index=gb + [weight_col], on=wide_value_vars
+            )
+            if agg_fn == "mean":
+                data = data.with_columns(pl.col(res_col) / pl.col(weight_col))
+            data = data.with_columns(pl.col("question").cast(pl.Enum(wide_value_vars)))
+            if gb == ["dummy_col"]:
+                data = data.drop("dummy_col")
+
+        # Check if categorical by looking at schema
+        elif isinstance(schema[res_col], (pl.Categorical, pl.Enum, pl.String)):
             cat_col = res_col
             value_col = "percent"
 
-            # Aggregate the data
+            # Aggregate the data, then get group totals as a window sum over the (small)
+            # aggregated frame - avoids a second full-data group_by plus a join
             data = raw_df.group_by(gb_dims + [res_col]).agg(pl.col(weight_col).sum().alias("percent"))
-
-            # Add weight_col to the data
-            totals = raw_df.group_by(gb_dims).agg(pl.col(weight_col).sum())
-            data = data.join(totals, on=gb_dims)
+            data = data.with_columns(pl.col("percent").sum().over(gb_dims).alias(weight_col))
 
             if agg_fn == "mean":
                 data = data.with_columns(pl.col("percent") / pl.col(weight_col))
@@ -387,14 +450,18 @@ def _wrangle_data(
     if gb_dims == ["dummy_col"]:
         data = data.drop("dummy_col")
 
-    # Streaming collect keeps memory down on large lazy pipelines; `streaming=` kwarg
-    # was renamed to `engine="streaming"` in polars 1.25+.
-    data = data.collect(engine="streaming").to_pandas()
-    # Force immediate garbage collection
-    gc.collect()  # Does not help much, but unlikely to hurt either
-
-    # How many datapoints the plot is based on. This is useful metainfo to display sometimes
-    filtered_size = raw_df.select(pl.col(weight_col).sum()).collect().item() / n_questions
+    # Collect the aggregation and the filtered weight total in a single pass.
+    # Both branches share the `raw_df` subplan, so comm_subplan_elim (on by default
+    # in collect_all) lets the streaming engine scan the filtered data once instead
+    # of twice. `filtered_size` is the number of datapoints the plot is based on -
+    # useful metainfo to display sometimes.
+    data, fsize = pl.collect_all(
+        [data, raw_df.select(pl.col(weight_col).sum())],
+        engine="streaming",
+    )
+    data = data.to_pandas()
+    # In wide form each row covers all questions at once, so no division is needed
+    filtered_size = fsize.item() / (1 if wide_value_vars is not None else n_questions)
 
     # Ensure derived columns have placeholder metadata so later lookups succeed
     for key in [value_col, cat_col]:
@@ -407,14 +474,16 @@ def _wrangle_data(
         meta = col_meta.get(c)
         col_dtype = data[c].dtype
         if meta and meta.categories and isinstance(col_dtype, pd.CategoricalDtype):
-            m_cats = meta.categories if meta.categories != "infer" else sorted(list(data[c].unique()))
+            uniques = data[c].unique()  # Hoisted: this loop was quadratic when done per category
+            present = set(uniques)
+            m_cats = meta.categories if meta.categories != "infer" else sorted(list(uniques))
             dtype_cats = utils.get_categories(col_dtype)
             if dtype_cats and len(set(dtype_cats) - set(m_cats)) > 0:
                 m_cats = dtype_cats
 
             # Get the categories that are in use
             if c != pp_desc.res_col or not meta.likert:
-                u_cats = [cv for cv in m_cats if cv in data[c].unique()]
+                u_cats = [cv for cv in m_cats if cv in present]
             else:
                 u_cats = m_cats
 

--- a/salk_toolkit/pp/wrangle.py
+++ b/salk_toolkit/pp/wrangle.py
@@ -245,17 +245,19 @@ def pp_transform_data(
                 filtered_df = filtered_df.drop("draw").join(draw_dfs[0].drop("question").lazy(), on=["id"], how="left")
                 draw_dfs = []  # To avoid adding draws again below
 
-        # Continuous longform groups can be aggregated in wide form and unpivoted after,
-        # so the n_rows x n_questions longform frame is never materialized. Requires all
-        # questions to share draws (or have none) and a weight-compatible aggregation.
+        # Longform groups can be aggregated in wide form (per question column) and only the
+        # small aggregates melted, so the n_rows x n_questions longform frame is never
+        # materialized. Requires all questions to share draws (or have none) and, for
+        # categorical questions, a percent-style aggregation.
         fschema = filtered_df.collect_schema()
         agg_fn_resolved = plot_meta.agg_fn or pp_desc.agg_fn or "mean"
+        cat_flags = [isinstance(fschema[c], (pl.Categorical, pl.Enum, pl.String)) for c in value_vars]
         if (
             plot_meta.data_format == "longform"
             and "question" in factor_cols
             and not draw_dfs
             and agg_fn_resolved != "posneg_mean"
-            and all(not isinstance(fschema[c], (pl.Categorical, pl.Enum, pl.String)) for c in value_vars)
+            and (not any(cat_flags) or (all(cat_flags) and agg_fn_resolved in ("mean", "sum")))
         ):
             wide_value_vars = value_vars
         else:
@@ -362,24 +364,44 @@ def _wrangle_data(
         agg_fn = pp_desc.agg_fn or "mean"
         agg_fn = plot_meta.agg_fn or agg_fn
 
-        if wide_value_vars is not None:  # Continuous question group, still in wide form
-            value_col = res_col
+        if wide_value_vars is not None:  # Question group, still in wide form
             gb = [d for d in gb_dims if d != "question"]
             if not gb:
                 raw_df = raw_df.with_columns(pl.lit("dummy").alias("dummy_col"))
                 gb = ["dummy_col"]
 
-            # Aggregate each question column per group, then unpivot the aggregated frame
-            if agg_fn in ["mean", "sum"]:  # Use weighted sum to compute both sum and mean
-                aggs = [(pl.col(q) * pl.col(weight_col)).sum().alias(q) for q in wide_value_vars]
-            else:  # median, min, max, etc. - ignore weight_col
-                aggs = [getattr(pl.col(q), agg_fn)().alias(q) for q in wide_value_vars]
-            data = raw_df.group_by(gb).agg(aggs + [pl.col(weight_col).sum()])
-            data = data.unpivot(
-                variable_name="question", value_name=res_col, index=gb + [weight_col], on=wide_value_vars
-            )
-            if agg_fn == "mean":
-                data = data.with_columns(pl.col(res_col) / pl.col(weight_col))
+            if isinstance(schema[wide_value_vars[0]], (pl.Categorical, pl.Enum, pl.String)):
+                cat_col = res_col
+                value_col = "percent"
+
+                # One small aggregation per question, all sharing the same filtered scan
+                # (comm_subplan_elim), concatenated afterwards. Emits exactly the observed
+                # (group, category) combos, like the melt-then-aggregate path would.
+                parts = [
+                    raw_df.group_by(gb + [pl.col(q).cast(pl.Categorical).alias(res_col)])
+                    .agg(pl.col(weight_col).sum().alias("percent"))
+                    .with_columns(pl.lit(q).alias("question"))
+                    for q in wide_value_vars
+                ]
+                data = pl.concat(parts)
+                data = data.with_columns(pl.col("percent").sum().over(gb + ["question"]).alias(weight_col))
+                if agg_fn == "mean":
+                    data = data.with_columns(pl.col("percent") / pl.col(weight_col))
+                # agg_fn is restricted to mean/sum by the wide-path guard
+
+            else:  # Continuous: aggregate each question column per group
+                value_col = res_col
+                if agg_fn in ["mean", "sum"]:  # Use weighted sum to compute both sum and mean
+                    aggs = [(pl.col(q) * pl.col(weight_col)).sum().alias(q) for q in wide_value_vars]
+                else:  # median, min, max, etc. - ignore weight_col
+                    aggs = [getattr(pl.col(q), agg_fn)().alias(q) for q in wide_value_vars]
+                data = raw_df.group_by(gb).agg(aggs + [pl.col(weight_col).sum()])
+                data = data.unpivot(
+                    variable_name="question", value_name=res_col, index=gb + [weight_col], on=wide_value_vars
+                )
+                if agg_fn == "mean":
+                    data = data.with_columns(pl.col(res_col) / pl.col(weight_col))
+
             data = data.with_columns(pl.col("question").cast(pl.Enum(wide_value_vars)))
             if gb == ["dummy_col"]:
                 data = data.drop("dummy_col")

--- a/salk_toolkit/utils.py
+++ b/salk_toolkit/utils.py
@@ -105,6 +105,7 @@ if TYPE_CHECKING:
 
 import numpy as np
 import pandas as pd
+from pandas.api.typing import DataFrameGroupBy
 import scipy
 from scipy.optimize import linear_sum_assignment
 from scipy.spatial.distance import cdist
@@ -112,6 +113,7 @@ from scipy.spatial.distance import cdist
 from altair.utils._importers import import_vl_convert
 
 import altair as alt
+from altair.utils.schemapi import UndefinedType
 import matplotlib.colors as mpc
 import hsluv  # type: ignore[import-untyped]
 
@@ -292,7 +294,7 @@ def match_sum_round(s: Sequence[float]) -> np.ndarray:
     return fs.astype("int")
 
 
-def min_diff(arr: Sequence[float]) -> float:
+def min_diff(arr: Sequence[float] | np.ndarray) -> float:
     """Return the smallest strictly positive difference between sorted values.
 
     Args:
@@ -444,7 +446,7 @@ def replace_constants(
             if isinstance(v, str) and v in constants_map:
                 d[k] = constants_map[v]
             elif isinstance(v, (dict, list)):
-                d[k] = replace_constants(v, constants_map, inplace=True, keep=keep)
+                d[k] = replace_constants(cast(Any, v), constants_map, inplace=True, keep=keep)
     # Handle list case
     elif isinstance(d, list):
         for i, v in enumerate(d):
@@ -515,19 +517,19 @@ default_color = "lightgrey"  # Something that stands out so it is easy to notice
 def to_alt_scale(
     scale: Mapping[str, str] | alt.Scale | None,
     order: Sequence[str] | None = None,
-) -> alt.Scale | alt.utils.schemapi.UndefinedType:
+) -> alt.Scale | UndefinedType:
     """Convert a mapping into an Altair scale (or None into alt.Undefined) while preserving category order.
 
     Preserving order matters because scale order overrides sort argument.
     """
 
     if scale is None:
-        scale = alt.Undefined  # type: ignore[assignment]
-    if isinstance(scale, dict):
+        return alt.Undefined
+    if isinstance(scale, Mapping):
         if order is None:
             order = list(scale.keys())
         # else: order = [ c for c in order if c in scale ]
-        scale = alt.Scale(
+        return alt.Scale(
             domain=list(order),
             range=[(scale[c] if c in scale else default_color) for c in order],
         )
@@ -744,7 +746,7 @@ def rel_wave_times(ws: Sequence[int], dts: Sequence[Any], dt0: pd.Timestamp | No
 def stable_rng(seed: int | str | bytes) -> np.random.Generator:
     """Return a platform-stable RNG using numpy's SFC64 bit generator."""
 
-    return np.random.Generator(np.random.SFC64(seed))
+    return np.random.Generator(np.random.SFC64(cast(Any, seed)))
 
 
 def stable_draws(n: int, n_draws: int, uid: str | int) -> np.ndarray:
@@ -812,7 +814,7 @@ def cut_nice_labels(
         breaks.insert(0, mi)
         lopen = True
 
-    obreaks = breaks.copy()
+    obreaks = list(breaks)
 
     if isint:
         breaks = list(map(int, breaks))
@@ -849,7 +851,7 @@ def rename_cats(df: pd.DataFrame, col: str, cat_map: Mapping[str, str]) -> None:
     """Rename categorical levels regardless of dtype quirks."""
 
     if df[col].dtype.name == "category":
-        df[col] = df[col].cat.rename_categories(cat_map)
+        df[col] = df[col].cat.rename_categories(cast(Any, cat_map))
     else:
         df[col] = df[col].replace(cat_map)
 
@@ -866,7 +868,7 @@ def str_replace(s: pd.Series, d: Mapping[str, str]) -> pd.Series:
 def merge_series(*lst: pd.Series | tuple[pd.Series, Sequence[Any]]) -> pd.Series:
     """Merge multiple series, preferentially taking non-null values."""
 
-    s = lst[0].astype("object").copy()
+    s = cast(pd.Series, lst[0]).astype("object").copy()
     for t in lst[1:]:
         if isinstance(t, tuple):
             ns, whitelist = t
@@ -948,7 +950,7 @@ def gb_cols_with_tooltip_fields(
     return out
 
 
-def gb_in(df: pd.DataFrame, gb_cols: Sequence[str]) -> pd.core.groupby.generic.DataFrameGroupBy | pd.DataFrame:
+def gb_in(df: pd.DataFrame, gb_cols: Sequence[str]) -> DataFrameGroupBy | pd.DataFrame:
     """Return ``df.groupby`` when ``gb_cols`` not empty; otherwise return ``df``."""
 
     # Convert to list for pandas groupby overload matching
@@ -1078,7 +1080,7 @@ def get_size(obj: object, seen: set[int] | None = None) -> int:
     return size
 
 
-def get_categories(dtype: object) -> list[object]:
+def get_categories(dtype: object) -> list[Any]:
     """Safely get categories from a pandas dtype.
 
     Args:
@@ -1087,10 +1089,9 @@ def get_categories(dtype: object) -> list[object]:
     Returns:
         List of categories if dtype has categories attribute, empty list otherwise.
     """
-    if hasattr(dtype, "categories"):
-        categories = dtype.categories
-        if categories is not None:
-            return list(categories)
+    categories = getattr(dtype, "categories", None)
+    if categories is not None:
+        return list(categories)
     return []
 
 
@@ -1103,9 +1104,7 @@ def get_ordered(dtype: object) -> bool:
     Returns:
         True if dtype is ordered, False otherwise.
     """
-    if hasattr(dtype, "ordered"):
-        return bool(dtype.ordered)
-    return False
+    return bool(getattr(dtype, "ordered", False))
 
 
 def escape_vega_label(label: str) -> str:
@@ -1135,6 +1134,7 @@ def read_yaml(model_desc_file: str) -> JSONValue:
 
     if ".yaml" not in model_desc_file:
         raise FileNotFoundError(f"Expecting {model_desc_file} to have a .yaml extension")
+    yaml_desc = None
     with open(model_desc_file) as stream:
         try:
             yaml_desc = yaml.safe_load(stream)
@@ -1467,6 +1467,7 @@ def plot_matrix_html(
 
     rstring = "XYZresponsiveXZY"  # Something we can replace easy
     specs, ncols = [], len(matrix[0])
+    repl = "1"  # Default responsive width multiplier if no plot sets one
     for i, p in enumerate(matrix):
         for j, pp in enumerate(p):
             if isinstance(pp, dict):

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -14,6 +14,8 @@ import altair as alt
 from salk_toolkit.pp import (
     _calculate_priority as calculate_priority,
     _transform_cont,
+    FacetMeta,
+    PlotInput,
     get_plot_fn,
     impute_factor_cols,
     matching_plots,
@@ -304,10 +306,10 @@ def test_transform_cont_full_streaming_pipeline(tmp_path) -> None:
     assert result.shape == (len(cols), 6)
 
 
-def test_get_plot_fn_legacy_wrapper_builds_chart() -> None:
-    """`get_plot_fn` should support the legacy `get_plot_fn(name)(**pparams)` convention."""
+def test_get_plot_fn_builds_chart_from_plot_input() -> None:
+    """`get_plot_fn` returns the plot function, callable with a PlotInput plus plot kwargs."""
 
-    plot = get_plot_fn("matrix")(
+    pi = PlotInput(
         data=pd.DataFrame(
             {
                 "row": ["A", "A", "B", "B"],
@@ -316,12 +318,12 @@ def test_get_plot_fn_legacy_wrapper_builds_chart() -> None:
             }
         ),
         facets=[
-            {"col": "row", "order": ["A", "B"], "colors": alt.Undefined},
-            {"col": "col", "order": ["X", "Y"], "colors": alt.Undefined},
+            FacetMeta(col="row", order=["A", "B"], colors=alt.Undefined),
+            FacetMeta(col="col", order=["X", "Y"], colors=alt.Undefined),
         ],
         value_col="value",
         val_format=".2",
-        log_colors=False,
     )
+    plot = get_plot_fn("matrix")(pi, log_colors=False)
 
     assert hasattr(plot, "to_dict")


### PR DESCRIPTION
Stacked on #54 (the pure `pp.py` -> package split), which is itself stacked on #51. Retargets down the stack automatically as each merges. **The package split lives in #54; this PR is only the follow-up refactor** — the actual logic changes.

Merge order: #51 -> #54 -> #52 -> salk_internal_package#95 (the `get_plot_fn` caller migration).

Optimizes the plot pipeline for 1M+ row datasets with wide question groups, and splits the 2050-line `pp.py` into a `salk_toolkit/pp/` package.

## Performance

Benchmarks on 1M rows × 50-question groups, filtered, measured before/after on identical data (outputs verified identical):

| Case | Before | After |
|---|---|---|
| `pp_transform_data`, continuous group | 1.51s | 0.17s |
| `pp_transform_data`, categorical (likert) group | 1.17s | 0.29s |
| `pp_transform_data`, categorical single column | 0.57s | 0.04s |
| `e2e_plot`, continuous group end-to-end | 1.80s | 0.18s |

Main changes:
- **Aggregate before melt**: question groups aggregate in wide form and only the small aggregates are melted, so the `n_rows × n_questions` longform frame is never materialized. Continuous groups use per-question weighted-sum expressions in one `group_by`; categorical groups run one small per-question `group_by` sharing the filtered scan (comm_subplan_elim) and concat the aggregates. Guarded to shared-or-absent draws (and mean/sum for categorical); everything else keeps the melt path. **Categorical output verified byte-identical against the old implementation** across mean/sum, filters, null categories and res-as-factor.
- **Predicate pushdown unblocked**: filters use `is_in` without `Utf8` casts (Enum values intersected with the vocabulary first), and the row index is only added when draws, sampling, or raw format actually need it.
- `matching_plots` answers `nonnegative` from metadata (`val_range`) instead of scanning all res columns on every render; unknown counts as not-nonnegative.
- Filter-only columns are projected away before the melt; categorical percent uses one `group_by` + window sum instead of two full-data `group_by`s and a join; `extract_column_meta` is cached per meta instance; deepcopies replaced with shallow copies in matrix-of-plots and the plot cache; quadratic `unique()` loop hoisted; `e2e_plot` no longer imputes factor_cols twice.

## Package split

`pp.py` → `salk_toolkit/pp/` (`common`, `registry`, `meta`, `matching`, `transforms`, `filters`, `wrangle`, `plotting`). `__init__` re-exports the previous public and internal surface, so all existing imports keep working (public `__all__` unchanged for star-importers).

## Cleanups and fixes along the way

- All grandfathered pyright errors in the pp modules and `utils.py` fixed (both now typecheck clean), including a real unbound-variable bug in `plot_matrix_html`'s responsive path.
- `posneg_mean` no longer leaks a `reverse_<weight_col>` column into maxdiff output (the `exclude()` hardcoded a weight column named `N`).
- Dead code removed: `_augment_draws` (only caller commented out), the raw-format `plot_meta.sample` block (a silent no-op — LazyFrame has neither `groupby` nor `sample`), unused `stk_plot_defaults` / `_get_all_plots`, commented-out priority weights.
- **`PlotMeta.sample` restored with working, efficient semantics**: a plot-declared cap on filtered rows applied via the deterministic id sample *before* group questions are melted (a raw plot on 1M rows materializes only `sample_n × n_questions` rows). `pp_desc.sample` / `plot_args["sample_size"]` override it. `ordered_population_sampled` now declares `sample=1000` instead of the hardcoded plot-name check in the pipeline; its behavior and tests are unchanged.
- **`get_plot_fn` now returns the registered plot function directly** (taking a `PlotInput` plus plot kwargs) instead of an 80-line dict-based legacy adapter whose only users were three call sites in salk_internal_package dev tools. Those callers are migrated in salk-ee/salk_internal_package#95, which should merge **after** this PR. `PlotInput.col_meta` now defaults to `{}` and `FacetMeta.ocol` defaults to `col` to make direct construction ergonomic.

## Verification

- Full suite: 222 passed / 1 skipped; ruff and pyright clean (pre-commit hooks pass).
- The one failure, `tests/test_plots.py::test_lines_hdi_basic`, **fails identically on pristine `origin/main`** (arviz-1 `hdi` rejects the fixture's draw count) — pre-existing, unrelated, needs its own fix.
- **Differential fuzz vs the unmodified logic**: 164 randomized scenarios (res = continuous/likert group, single cont/cat/ordered col x 11 filter shapes incl. ranges, meta-groups, question subsets x mean/sum/median x factor combos incl. numeric discretization, plus convert_res, cont transforms incl. custom numpy row transforms, shared and per-question draws_data, maxdiff/posneg, sampling, pl_filter) run through `pp_transform_data` on both the pure-split commit (#54, i.e. the original logic) and this branch: **zero differences** in normalized output (values at 6 significant digits, category sets and order, value/cat col, val_format, val_range, filtered_size). The 5 scenarios that error (pre-existing discretize-of-NaN edge) fail identically on both sides.
- Old-vs-new equivalence: categorical group descriptors produce byte-identical CSV output between the pre-change implementation and the wide path; continuous wide path verified against manual pandas weighted means (nulls, filters, `filtered_size`, question ordering, draws, median agg, question-only edge case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



