### PR TITLE
Make pyright hermetic via a root pyrightconfig.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tags
 *.sav
 *.csv
 *.json
+!pyrightconfig.json
 *.parquet
 
 # Byte-compiled / optimized / DLL files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,29 +106,7 @@ docformat = "google"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
-[tool.pyright]
-pythonVersion = "3.12"
-typeCheckingMode = "basic"
-include = [
-    "salk_toolkit",
-    "tests",
-]
-reportUnknownMemberType = false
-reportUnknownArgumentType = false
-reportUnknownVariableType = false
-reportAttributeAccessIssue = false
-reportArgumentType = false
-reportReturnType = true
-reportCallIssue = true
-reportOptionalIterable = true
-reportIndexIssue = true
-reportOptionalSubscript = true
-reportOptionalMemberAccess = true
-reportOptionalOperand = true
-reportGeneralTypeIssues = true
-exclude = [
-    "tests",
-    "**/__pycache__",
-    "**/.ipynb_checkpoints",
-    "**.ipynb",
-]
+# Pyright configuration lives in pyrightconfig.json (at the repo root) rather than
+# here: a root-level pyrightconfig.json is discovered before any parent-directory
+# config during pyright's upward search, which keeps type-checking scoped to this
+# package when the repo is checked out inside a larger workspace.

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,26 @@
+{
+  "pythonVersion": "3.12",
+  "typeCheckingMode": "basic",
+  "include": [
+    "salk_toolkit",
+    "tests"
+  ],
+  "exclude": [
+    "**/__pycache__",
+    "**/.ipynb_checkpoints",
+    "**.ipynb"
+  ],
+  "reportUnknownMemberType": false,
+  "reportUnknownArgumentType": false,
+  "reportUnknownVariableType": false,
+  "reportAttributeAccessIssue": false,
+  "reportArgumentType": false,
+  "reportReturnType": true,
+  "reportCallIssue": true,
+  "reportOptionalIterable": true,
+  "reportIndexIssue": true,
+  "reportOptionalSubscript": true,
+  "reportOptionalMemberAccess": true,
+  "reportOptionalOperand": true,
+  "reportGeneralTypeIssues": true
+}


### PR DESCRIPTION
**Stack:** base of #55 (which contains the test fixes). Review this one first.

## Problem

Pyright was effectively unusable in this repo. With no repo-local `pyrightconfig.json`, pyright's **upward config search** reached a parent-directory config that globbed sibling packages/worktrees, so a bare `pyright` invocation:

- scanned hundreds of unrelated files across the workspace — appearing to **hang** (>300s), and
- ran without this package's rule suppressions, reporting **~770 spurious errors** (mostly `reportArgumentType`/`reportAttributeAccessIssue`, which this package deliberately disables due to pandas/numpy/altair stub noise).

Scoped correctly, the package **source is already clean**. The only real errors were 92, all in `tests/` — which weren't being type-checked at all.

## Changes (config only — no source or test behavior change)

- Add a root **`pyrightconfig.json`**. At the repo root it wins pyright's upward search before any parent config, scoping analysis to this package (~22–42s, no hang). It mirrors the former `[tool.pyright]` settings but **keeps tests in scope** — the old block listed `tests` under `include` yet also under `exclude`, silently skipping them.
- Remove the now-inert `[tool.pyright]` block from `pyproject.toml`; leave a pointer comment.
- Whitelist `pyrightconfig.json` past the blanket `*.json` `.gitignore` rule.

With tests now in scope, pyright reports 92 errors, all in `tests/` — fixed in #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)