### PR TITLE
Re-export custom_meta_key from salk_toolkit.io (io-split regression)

### DIFF
--- a/salk_toolkit/io/__init__.py
+++ b/salk_toolkit/io/__init__.py
@@ -46,6 +46,7 @@ from salk_toolkit.io.meta import (
     update_meta_with_model_fields,
 )
 from salk_toolkit.io.parquet import (
+    custom_meta_key,  # noqa: F401  # imported from here by dms-plots-api
     read_parquet_metadata,
     read_parquet_with_metadata,
     replace_data_meta_in_parquet,


### PR DESCRIPTION
The #53 io split moved `custom_meta_key` to `io/parquet.py` without a re-export. dms-plots-api's `app/remote_reader.py:14` does `from salk_toolkit.io import custom_meta_key` at app startup, so any plots-api image built against current main crash-loops (and PR salk-ee/dms-plots-api#2's CI fails on collection).

One-line re-export in `io/__init__.py`; `from salk_toolkit.io import custom_meta_key` verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)