### PR TITLE
fix(payload): uncolored facets carry colors=None instead of an invented palette

### DIFF
--- a/salk_toolkit/payload.py
+++ b/salk_toolkit/payload.py
@@ -183,9 +183,9 @@ def _plain_colors(facet: FacetMeta) -> Optional[Dict[str, str]]:
 
 
 def _facet_colors(facet: FacetMeta) -> Optional[Dict[str, str]]:
-    """Facet colors as plain hex, or None when the meta declares none — the spec
-    path leaves such facets to the renderer's default scheme, so inventing colors
-    here made the two paths render differently (dms#40 parity finding)."""
+    """Facet colors as plain hex, or None when the meta declares none.
+
+    Uncolored facets are the renderer's to colour (its default categorical scheme)."""
     return _plain_colors(facet)
 
 

--- a/salk_toolkit/payload.py
+++ b/salk_toolkit/payload.py
@@ -183,12 +183,10 @@ def _plain_colors(facet: FacetMeta) -> Optional[Dict[str, str]]:
 
 
 def _facet_colors(facet: FacetMeta) -> Optional[Dict[str, str]]:
-    """Facet colors as plain hex; falls back to salk's default palette (what Vega would render)."""
-    plain = _plain_colors(facet)
-    if plain is not None or not facet.order:
-        return plain
-    palette = utils.altair_default_config["range"]["category"]
-    return {str(c): palette[i % len(palette)] for i, c in enumerate(facet.order)}
+    """Facet colors as plain hex, or None when the meta declares none — the spec
+    path leaves such facets to the renderer's default scheme, so inventing colors
+    here made the two paths render differently (dms#40 parity finding)."""
+    return _plain_colors(facet)
 
 
 def _cell(frame: pd.DataFrame, title: str, keys: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/test_plot_payload.py
+++ b/tests/test_plot_payload.py
@@ -116,8 +116,8 @@ def test_payload_shape_columns(small_pi_fixture, ppd_columns):
 
 
 def test_payload_uncolored_facet_colors_stay_none(barbell_cell_pi_and_ppd):
-    """A facet with no metadata colors carries None (renderer applies its own default,
-    matching the spec path — dms#40 parity finding); explicit colors stay."""
+    """A facet with no metadata colors carries None (the renderer owns the default
+    scheme); explicit colors stay."""
 
     pi, ppd = barbell_cell_pi_and_ppd
     pl = pp.create_plot_payload(pi, ppd)
@@ -825,8 +825,7 @@ def test_payload_geobest_smoke(geobest_cell_pi_and_ppd):
 
 
 def test_payload_geobest_null_colors_smoke(geobest_cell_pi_and_ppd):
-    """An uncolored winner facet stays None; renderers own the fallback (the dms
-    frontend covers this exact case — its plotDataGeobestNullColors fixture)."""
+    """An uncolored winner facet stays None; the renderer owns the fallback."""
 
     pi, ppd = geobest_cell_pi_and_ppd
     pi.col_meta["candidate"] = GroupOrColumnMeta(categories=["Alice", "Bob"])

--- a/tests/test_plot_payload.py
+++ b/tests/test_plot_payload.py
@@ -115,17 +115,15 @@ def test_payload_shape_columns(small_pi_fixture, ppd_columns):
         assert f["colors"] is None or all(isinstance(c, str) for c in f["colors"].values())
 
 
-def test_payload_synthesizes_default_palette_for_uncolored_facet(barbell_cell_pi_and_ppd):
-    """A facet with no metadata colors gets salk's default palette as plain hex; explicit colors stay."""
-
-    from salk_toolkit.utils import altair_default_config
+def test_payload_uncolored_facet_colors_stay_none(barbell_cell_pi_and_ppd):
+    """A facet with no metadata colors carries None (renderer applies its own default,
+    matching the spec path — dms#40 parity finding); explicit colors stay."""
 
     pi, ppd = barbell_cell_pi_and_ppd
     pl = pp.create_plot_payload(pi, ppd)
-    palette = altair_default_config["range"]["category"]
 
     question = next(f for f in pl["facets"] if f["col"] == "question")
-    assert question["colors"] == {"Q1": palette[0], "Q2": palette[1], "Q3": palette[2]}
+    assert question["colors"] is None
 
     group = next(f for f in pl["facets"] if f["col"] == "group")
     assert group["colors"] == {"Group A": "#c00000", "Group B": "#00c000"}
@@ -827,17 +825,15 @@ def test_payload_geobest_smoke(geobest_cell_pi_and_ppd):
 
 
 def test_payload_geobest_null_colors_smoke(geobest_cell_pi_and_ppd):
-    """An uncolored winner facet resolves to salk's default palette as plain hex, not None."""
-
-    from salk_toolkit.utils import altair_default_config
+    """An uncolored winner facet stays None; renderers own the fallback (the dms
+    frontend covers this exact case — its plotDataGeobestNullColors fixture)."""
 
     pi, ppd = geobest_cell_pi_and_ppd
     pi.col_meta["candidate"] = GroupOrColumnMeta(categories=["Alice", "Bob"])
 
     pl = pp.create_plot_payload(pi, ppd)
-    palette = altair_default_config["range"]["category"]
     assert pl["facets"][0]["col"] == "candidate"
-    assert pl["facets"][0]["colors"] == {"Alice": palette[0], "Bob": palette[1]}
+    assert pl["facets"][0]["colors"] is None
 
 
 @pytest.fixture


### PR DESCRIPTION
Found by dms#40's facet parity harness: for colour facets with **no meta colors** (gender, education, unstyled batteries), `_facet_colors` cycled `altair_default_config`'s streamlit palette into the payload, while `create_plot`'s spec leaves such facets to the renderer's default scheme (tableau in the dms frontend, matching what Vega rendered). The two paths therefore coloured the same chart differently.

With this change the payload carries `colors: None` for such facets and the renderer applies its own fallback — dms's ECharts renderers already do (their `plotDataGeobestNullColors` fixture covers the geobest case explicitly). Explicit meta colors (parties, likert ramps) are untouched.

Erik picked tableau as the single palette (2026-07-14); dms#40 removes its parity-test palette normalization once this lands in the plots-API vendor copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)