### PR TITLE
PlotPayload v1 extensions: facet_dims/n_inner/per-cell scales, colors:null for uncolored facets, facet vocabulary

### DIFF
--- a/salk_toolkit/payload.py
+++ b/salk_toolkit/payload.py
@@ -270,7 +270,8 @@ def create_plot_payload(
         "value_col": dry_pi.value_col,
         "cat_col": dry_pi.cat_col,
         "val_format": dry_pi.val_format,
-        "filtered_size": dry_pi.filtered_size,
+        "filtered_size": dry_pi.filtered_size,  # post-filter weight (aka displayed_n)
+        "total_n": dry_pi.total_n,  # pre-filter total weight; filter% = filtered_size / total_n
         "value_range": value_range,
         "facets": facets_payload,
         "outer_factors": outer_factors,

--- a/salk_toolkit/payload.py
+++ b/salk_toolkit/payload.py
@@ -276,8 +276,7 @@ def create_plot_payload(
         "value_range": value_range,
         "facets": facets_payload,
         "outer_factors": outer_factors,
-        # Resolved facet split: outer_factors == factor_cols[n_inner:]. factor_cols is
-        # what /plot's PlotResponse.factor_cols carried (the Sort control's source).
+        # Invariant: outer_factors == factor_cols[n_inner:]
         "factor_cols": list(dry_pi.factor_cols),
         "n_inner": dry_pi.n_inner,
         "grid": {

--- a/salk_toolkit/payload.py
+++ b/salk_toolkit/payload.py
@@ -183,9 +183,9 @@ def _plain_colors(facet: FacetMeta) -> Optional[Dict[str, str]]:
 
 
 def _facet_colors(facet: FacetMeta) -> Optional[Dict[str, str]]:
-    """Facet colors as plain hex, or None when the meta declares none — the spec
-    path leaves such facets to the renderer's default scheme, so inventing colors
-    here made the two paths render differently (dms#40 parity finding)."""
+    """Facet colors as plain hex, or None when the meta declares none.
+
+    Uncolored facets are the renderer's to colour (its default categorical scheme)."""
     return _plain_colors(facet)
 
 

--- a/salk_toolkit/payload.py
+++ b/salk_toolkit/payload.py
@@ -276,8 +276,8 @@ def create_plot_payload(
         "value_range": value_range,
         "facets": facets_payload,
         "outer_factors": outer_factors,
-        # Invariant: outer_factors == factor_cols[n_inner:]
-        "factor_cols": list(dry_pi.factor_cols),
+        # Invariant: outer_factors == facet_dims[n_inner:]
+        "facet_dims": list(dry_pi.factor_cols),
         "n_inner": dry_pi.n_inner,
         "grid": {
             "rows": len(cells),

--- a/salk_toolkit/payload.py
+++ b/salk_toolkit/payload.py
@@ -191,7 +191,9 @@ def _facet_colors(facet: FacetMeta) -> Optional[Dict[str, str]]:
     return {str(c): palette[i % len(palette)] for i, c in enumerate(facet.order)}
 
 
-def _cell(frame: pd.DataFrame, title: str, keys: Dict[str, Any]) -> Dict[str, Any]:
+def _cell(
+    frame: pd.DataFrame, title: str, keys: Dict[str, Any], scale: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
     """Serialize one cell's DataFrame into a `cells[i][j]` entry."""
     columns = list(frame.columns)
     return {
@@ -199,6 +201,8 @@ def _cell(frame: pd.DataFrame, title: str, keys: Dict[str, Any]) -> Dict[str, An
         "keys": keys,
         "columns": columns,
         "data": {c: _serialize_column(frame[c]) for c in columns},
+        # Per-cell colour scale (geo facets: each cell keeps its own domain/ramp)
+        "scale": scale,
     }
 
 
@@ -246,16 +250,18 @@ def create_plot_payload(
             }
         )
         result = plot_fn(cell_pi, **plot_kwargs)
+        cell_scale = None
         if uses_return_df and isinstance(result, PlotInput):  # authoritative path (return_df)
             frame = result.data
         else:  # fallback: read frame / scale / geo back off the built chart
             frame = _chart_frame(result)
             if frame is None:
                 raise UnsupportedPayloadError(pp_desc.plot)
-            scale = scale or _chart_scale(result)
+            cell_scale = _chart_scale(result)
+            scale = scale or cell_scale
             geo = geo or _chart_geo(result)
         keys = {oc: _to_json_scalar(v) for oc, v in zip(outer_factors, comb)}
-        cell_list.append(_cell(frame, "-".join(map(str, comb)), keys))
+        cell_list.append(_cell(frame, "-".join(map(str, comb)), keys, scale=cell_scale))
 
     cells = [list(row) for row in utils.batch(cell_list, n_facet_cols)]
     value_range = [_to_json_scalar(v) for v in dry_pi.value_range] if dry_pi.value_range is not None else None
@@ -270,6 +276,10 @@ def create_plot_payload(
         "value_range": value_range,
         "facets": facets_payload,
         "outer_factors": outer_factors,
+        # Resolved facet split: outer_factors == factor_cols[n_inner:]. factor_cols is
+        # what /plot's PlotResponse.factor_cols carried (the Sort control's source).
+        "factor_cols": list(dry_pi.factor_cols),
+        "n_inner": dry_pi.n_inner,
         "grid": {
             "rows": len(cells),
             "cols": n_facet_cols if outer_factors else 1,

--- a/salk_toolkit/payload.py
+++ b/salk_toolkit/payload.py
@@ -24,7 +24,7 @@ from salk_toolkit.validation import PlotDescriptor
 
 # ColorBrewer stops for Vega's "yellowgreen"/"redyellowgreen" schemes -- Vega resolves scheme names
 # to hex only at render, so the resolved ramp is never on the chart object. Used by the fallback
-# path; the `payload=True` matrix/geoplot supply their own resolved stops via `extras`.
+# (chart-scraping) path's `_chart_scale`.
 _SCHEME_STOPS: Dict[str, List[str]] = {
     "yellowgreen": ["#ffffe5", "#f7fcb9", "#d9f0a3", "#addd8e", "#78c679", "#41ab5d", "#238443", "#006837", "#004529"],
     "redyellowgreen": [
@@ -170,7 +170,10 @@ def _serialize_column(series: pd.Series) -> List[Any]:
 
 
 def _plain_colors(facet: FacetMeta) -> Optional[Dict[str, str]]:
-    """Reduce a facet's Altair-ready `colors` (Scale / dict / Undefined) to a plain hex map or None."""
+    """Reduce a facet's Altair-ready `colors` (Scale / dict / Undefined) to a plain hex map or None.
+
+    None means the meta declares no colors: the facet is the renderer's to colour
+    (its default categorical scheme)."""
     colors = facet.colors
     if isinstance(colors, alt.Scale):
         domain, rng = colors.domain, colors.range
@@ -180,13 +183,6 @@ def _plain_colors(facet: FacetMeta) -> Optional[Dict[str, str]]:
     if isinstance(colors, dict):
         return _normalize_color_dict(cast(Dict[str, Any], colors))
     return None
-
-
-def _facet_colors(facet: FacetMeta) -> Optional[Dict[str, str]]:
-    """Facet colors as plain hex, or None when the meta declares none.
-
-    Uncolored facets are the renderer's to colour (its default categorical scheme)."""
-    return _plain_colors(facet)
 
 
 def _cell(
@@ -230,12 +226,12 @@ def create_plot_payload(
 
     # Sourced from dry_pi before the per-cell loop so cell mutations can't corrupt it
     facets_payload = [
-        {"col": f.col, "order": list(f.order), "colors": _facet_colors(f), "neutrals": list(f.neutrals)}
+        {"col": f.col, "order": list(f.order), "colors": _plain_colors(f), "neutrals": list(f.neutrals)}
         for f in dry_pi.facets
     ]
 
     combs = list(it.product(*[utils.get_categories(data[fc].dtype) for fc in outer_factors]))
-    scale = geo = None
+    geo = None
     cell_list: List[Dict[str, Any]] = []
     for comb in combs:  # `it.product()` of no factors yields one empty comb = one cell
         # deepcopy facets: plots may reorder FacetMeta in place across the shared cells
@@ -256,12 +252,13 @@ def create_plot_payload(
             if frame is None:
                 raise UnsupportedPayloadError(pp_desc.plot)
             cell_scale = _chart_scale(result)
-            scale = scale or cell_scale
             geo = geo or _chart_geo(result)
         keys = {oc: _to_json_scalar(v) for oc, v in zip(outer_factors, comb)}
         cell_list.append(_cell(frame, "-".join(map(str, comb)), keys, scale=cell_scale))
 
     cells = [list(row) for row in utils.batch(cell_list, n_facet_cols)]
+    # Top-level scale kept for back-compat: the first per-cell scale
+    scale = next((c["scale"] for c in cell_list if c["scale"]), None)
     value_range = [_to_json_scalar(v) for v in dry_pi.value_range] if dry_pi.value_range is not None else None
 
     return {
@@ -275,7 +272,9 @@ def create_plot_payload(
         "value_range": value_range,
         "facets": facets_payload,
         "outer_factors": outer_factors,
-        # Invariant: outer_factors == facet_dims[n_inner:]
+        # facet_dims/n_inner: the resolved facet split in descriptor vocabulary (pre-translation).
+        # outer_factors is the rendered view of facet_dims[n_inner:] — identical for <=1 outer facet
+        # and no translate; otherwise translated, reversed, and (>2) merged into one joined key.
         "facet_dims": list(dry_pi.facet_dims),
         "n_inner": dry_pi.n_inner,
         "grid": {

--- a/salk_toolkit/payload.py
+++ b/salk_toolkit/payload.py
@@ -277,7 +277,7 @@ def create_plot_payload(
         "facets": facets_payload,
         "outer_factors": outer_factors,
         # Invariant: outer_factors == facet_dims[n_inner:]
-        "facet_dims": list(dry_pi.factor_cols),
+        "facet_dims": list(dry_pi.facet_dims),
         "n_inner": dry_pi.n_inner,
         "grid": {
             "rows": len(cells),

--- a/salk_toolkit/payload.py
+++ b/salk_toolkit/payload.py
@@ -268,7 +268,7 @@ def create_plot_payload(
         "cat_col": dry_pi.cat_col,
         "val_format": dry_pi.val_format,
         "filtered_size": dry_pi.filtered_size,  # post-filter weight (aka displayed_n)
-        "total_n": dry_pi.total_n,  # pre-filter total weight; filter% = filtered_size / total_n
+        "total_size": dry_pi.total_size,  # pre-filter total weight; filter% = filtered_size / total_size
         "value_range": value_range,
         "facets": facets_payload,
         "outer_factors": outer_factors,

--- a/salk_toolkit/payload.py
+++ b/salk_toolkit/payload.py
@@ -183,12 +183,10 @@ def _plain_colors(facet: FacetMeta) -> Optional[Dict[str, str]]:
 
 
 def _facet_colors(facet: FacetMeta) -> Optional[Dict[str, str]]:
-    """Facet colors as plain hex; falls back to salk's default palette (what Vega would render)."""
-    plain = _plain_colors(facet)
-    if plain is not None or not facet.order:
-        return plain
-    palette = utils.altair_default_config["range"]["category"]
-    return {str(c): palette[i % len(palette)] for i, c in enumerate(facet.order)}
+    """Facet colors as plain hex, or None when the meta declares none — the spec
+    path leaves such facets to the renderer's default scheme, so inventing colors
+    here made the two paths render differently (dms#40 parity finding)."""
+    return _plain_colors(facet)
 
 
 def _cell(

--- a/salk_toolkit/pp.py
+++ b/salk_toolkit/pp.py
@@ -133,8 +133,8 @@ class PlotInput:
     outer_factors: List[str] = field(default_factory=list)
     plot_args: Dict[str, Any] = field(default_factory=dict)
     n_facet_cols: Optional[int] = None  # stashed by create_plot for payload consumers
-    factor_cols: List[str] = field(default_factory=list)  # resolved facet list; outer_factors == factor_cols[n_inner:]
-    n_inner: int = 0  # how many factor_cols the plot consumes as inner facets
+    facet_dims: List[str] = field(default_factory=list)  # resolved facet dimensions; outer_factors == facet_dims[n_inner:]
+    n_inner: int = 0  # how many facet_dims the plot consumes as inner facets
     return_df: bool = False  # payload=True plots return the prepared PlotInput instead of a chart
 
     def model_copy(self, *, deep: bool = False, update: dict[str, Any] | None = None) -> "PlotInput":
@@ -1691,8 +1691,8 @@ def create_plot(
             order = data.groupby(q, observed=True)["ordering_value"].mean().sort_values(ascending=False).index
             data[q] = pd.Categorical(data[q], list(order))
 
-    # Stash the resolved facet split for payload consumers (wire: factor_cols/n_inner)
-    pi.factor_cols = list(factor_cols)
+    # Stash the resolved facet split for payload consumers (wire: facet_dims/n_inner)
+    pi.facet_dims = list(factor_cols)
     pi.n_inner = n_inner
 
     # Handle internal facets (and translate as needed)

--- a/salk_toolkit/pp.py
+++ b/salk_toolkit/pp.py
@@ -123,7 +123,7 @@ class PlotInput:
     val_format: str = "%"
     val_range: Optional[Tuple[Optional[float], Optional[float]]] = None
     filtered_size: float = 0.0  # post-filter weight (the "displayed_n" the plot is based on)
-    total_n: float = 0.0  # pre-filter total weight, so consumers can show "filtered to X%"
+    total_size: float = 0.0  # pre-filter total weight, so consumers can show "filtered to X%"
     facets: List[FacetMeta] = field(default_factory=list)
     translate: Optional[Callable[[str], str]] = None
     tooltip: List[Any] = field(default_factory=list)
@@ -426,7 +426,7 @@ def get_plot_fn(plot_name: str) -> Callable[..., AltairChart]:
             val_format=cast(str, pparams.get("val_format") or "%"),
             val_range=cast(Optional[Tuple[Optional[float], Optional[float]]], pparams.get("val_range")),
             filtered_size=float(cast(object, pparams.get("filtered_size") or 0.0)),
-            total_n=float(cast(object, pparams.get("total_n") or 0.0)),
+            total_size=float(cast(object, pparams.get("total_size") or 0.0)),
             facets=facets_list,
             tooltip=cast(List[Any], pparams.get("tooltip") or []),
             value_range=cast(Optional[Tuple[float, float]], pparams.get("value_range")),
@@ -1298,7 +1298,7 @@ def _wrangle_data(
     weight_col: str,
     pp_desc: PlotDescriptor,
     n_questions: int,
-    total_n: float = 0.0,
+    total_size: float = 0.0,
 ) -> PlotInput:
     """Aggregate filtered data into a structured ``PlotInput`` model for create_plot."""
 
@@ -1460,7 +1460,7 @@ def _wrangle_data(
         value_col=value_col,
         cat_col=cat_col,
         filtered_size=filtered_size,
-        total_n=total_n,
+        total_size=total_size,
     )
 
 

--- a/salk_toolkit/pp.py
+++ b/salk_toolkit/pp.py
@@ -7,7 +7,7 @@ It maps annotated survey data to Altair charts by:
 - discovering eligible plots via the registry metadata in `salk_toolkit.plots`
 - lazily transforming data with Polars, including filters, melts, draws, and
   aggregation helpers such as `pp_transform_data` / `_wrangle_data`
-- enriching metadata (`update_data_meta_with_pp_desc`, `impute_factor_cols`,
+- enriching metadata (`update_data_meta_with_pp_desc`, `impute_facet_dims`,
   `matching_plots`) so dashboards and CLI tools can reason about aliases,
   ordering, draws, and group scales
 - building final Altair specs with `create_plot`, colour utilities, tooltips,
@@ -637,8 +637,8 @@ def matching_plots(
     pp_desc = soft_validate(pp_desc, PlotDescriptor)
 
     if impute:
-        factor_cols = impute_factor_cols(pp_desc, extract_column_meta(data_meta), get_plot_meta(pp_desc.plot))
-        pp_desc = pp_desc.model_copy(update={"factor_cols": factor_cols})
+        facet_dims = impute_facet_dims(pp_desc, extract_column_meta(data_meta), get_plot_meta(pp_desc.plot))
+        pp_desc = pp_desc.model_copy(update={"facet_dims": facet_dims})
 
     col_meta, _ = _update_data_meta_with_pp_desc(data_meta, pp_desc)
 
@@ -674,9 +674,9 @@ def matching_plots(
         if cat_vals:
             nonneg = min(cat_vals) >= 0
 
-    factor_cols = pp_desc.factor_cols
+    facet_dims = pp_desc.facet_dims
     facet_metas = []
-    for cn in factor_cols:
+    for cn in facet_dims:
         meta = col_meta.get(cn, GroupOrColumnMeta())
         facet_metas.append({"name": cn, **meta.model_dump(mode="python")})
     # Determine if data is categorical
@@ -1065,7 +1065,7 @@ def pp_transform_data(
 
     # Figure out which columns we actually need
     weight_col = data_meta.weight_col or "row_weights"
-    factor_cols = list(pp_desc.factor_cols).copy()
+    facet_dims = list(pp_desc.facet_dims).copy()
 
     # Ensure weight column is present (fill with 1.0 if not)
     if weight_col not in all_col_names:
@@ -1076,11 +1076,11 @@ def pp_transform_data(
 
     # For transforming purposest, res_col is not a factor.
     # It will be made one for categorical plots for plotting part, but for pp_transform_data, remove it
-    if pp_desc.res_col in factor_cols:
-        factor_cols.remove(pp_desc.res_col)
+    if pp_desc.res_col in facet_dims:
+        facet_dims.remove(pp_desc.res_col)
     base_cols = list(columns) if columns is not None else []
     extra_cols = base_cols + ([weight_col] + (["draw"] if plot_meta.draws else []))
-    cols = [pp_desc.res_col] + factor_cols + list(pp_desc.filter.keys() if pp_desc.filter else [])
+    cols = [pp_desc.res_col] + facet_dims + list(pp_desc.filter.keys() if pp_desc.filter else [])
     cols += [c for c in extra_cols if c in all_col_names and c not in cols]
 
     # If any aliases are used, cconvert them to column names according to the data_meta
@@ -1110,7 +1110,7 @@ def pp_transform_data(
         filtered_df = df
 
     # Discretize factor columns that are numeric
-    for c in factor_cols:
+    for c in facet_dims:
         if c in cols and schema[c].is_numeric():
             current_meta = c_meta.get(c)
             filtered_df, labels = _discretize_continuous(filtered_df, c, current_meta)
@@ -1208,7 +1208,7 @@ def pp_transform_data(
     if pp_desc.res_col in gc_dict:
         value_vars = [c for c in gc_dict[pp_desc.res_col] if c in cols]
         n_questions = len(value_vars)  # Only cols that exist in the data
-        id_vars = [c for c in cols if (c not in value_vars or c in factor_cols)]
+        id_vars = [c for c in cols if (c not in value_vars or c in facet_dims)]
         prefix = original_question_meta.col_prefix or ""
         categories = [v.removeprefix(prefix) for v in value_vars]
         question_meta = _question_meta_clone(original_question_meta, categories)
@@ -1256,7 +1256,7 @@ def pp_transform_data(
         filtered_df = filtered_df.with_columns(pl.col("question").cast(pl.Enum(value_vars)))
     else:
         n_questions = 1
-        if "question" in factor_cols:
+        if "question" in facet_dims:
             filtered_df = filtered_df.with_columns(pl.lit(pp_desc.res_col).alias("question").cast(pl.Categorical))
             question_meta = _question_meta_clone(original_question_meta, categories=[pp_desc.res_col])
             if original_question_colors:
@@ -1264,7 +1264,7 @@ def pp_transform_data(
             c_meta["question"] = question_meta
 
     # Aggregate the data into right shape
-    pi = _wrangle_data(filtered_df, c_meta, factor_cols, weight_col, pp_desc, n_questions)
+    pi = _wrangle_data(filtered_df, c_meta, facet_dims, weight_col, pp_desc, n_questions)
 
     pi.val_format = val_format
     pi.val_range = val_range  # Currently not used
@@ -1284,7 +1284,7 @@ def pp_transform_data(
 def _wrangle_data(
     raw_df: pl.LazyFrame,
     col_meta: MutableMapping[str, GroupOrColumnMeta],
-    factor_cols: List[str],
+    facet_dims: List[str],
     weight_col: str,
     pp_desc: PlotDescriptor,
     n_questions: int,
@@ -1300,10 +1300,10 @@ def _wrangle_data(
     draws = plot_meta.draws
     data_format = plot_meta.data_format
 
-    # if pp_desc['res_col'] in factor_cols: factor_cols.remove(pp_desc['res_col']) # Res cannot also be a factor
+    # if pp_desc['res_col'] in facet_dims: facet_dims.remove(pp_desc['res_col']) # Res cannot also be a factor
 
     # Determine the groupby dimensions
-    gb_dims = factor_cols + (["draw"] if draws else []) + (["id"] if plot_meta.data_format == "raw" else [])
+    gb_dims = facet_dims + (["draw"] if draws else []) + (["id"] if plot_meta.data_format == "raw" else [])
 
     # If we have no groupby dimensions, add a dummy one so we don't have to handle the empty case
     if len(gb_dims) == 0:
@@ -1571,39 +1571,39 @@ def _create_tooltip(
     return tooltips, data
 
 
-def _remove_from_internal_fcols(cname: str, factor_cols: List[str], n_inner: int) -> int:
+def _remove_from_internal_fcols(cname: str, facet_dims: List[str], n_inner: int) -> int:
     """Shift ``cname`` out of the inner facet slice while preserving order."""
 
-    if cname not in factor_cols[:n_inner]:
+    if cname not in facet_dims[:n_inner]:
         return n_inner
-    factor_cols.remove(cname)
-    if n_inner > len(factor_cols):
+    facet_dims.remove(cname)
+    if n_inner > len(facet_dims):
         n_inner -= 1
-    factor_cols.insert(n_inner, cname)
+    facet_dims.insert(n_inner, cname)
     return n_inner
 
 
-def _inner_outer_factors(
-    factor_cols: List[str],
+def _inner_outer_facets(
+    facet_dims: List[str],
     pp_desc: PlotDescriptor,
     plot_meta: PlotMeta,
 ) -> tuple[List[str], int]:
-    """Return `(factor_cols, n_inner)` after respecting descriptor overrides."""
+    """Return `(facet_dims, n_inner)` after respecting descriptor overrides."""
 
     # Determine how many factors to use as inner facets
     in_f = pp_desc.internal_facet if pp_desc.internal_facet is not None else False
     res_col = pp_desc.res_col
     n_min_f, n_rec_f = plot_meta.n_facets or (0, 0)
     n_inner: int = (n_rec_f if in_f else n_min_f) if isinstance(in_f, bool) else int(in_f)  # type: ignore[arg-type]
-    if n_inner > len(factor_cols):
-        n_inner = len(factor_cols)
+    if n_inner > len(facet_dims):
+        n_inner = len(facet_dims)
 
     # If question facet as inner facet for a no_question_facet plot, just move it out
     if plot_meta.no_question_facet:
-        n_inner = _remove_from_internal_fcols("question", factor_cols, n_inner)
-        n_inner = _remove_from_internal_fcols(res_col, factor_cols, n_inner)
+        n_inner = _remove_from_internal_fcols("question", facet_dims, n_inner)
+        n_inner = _remove_from_internal_fcols(res_col, facet_dims, n_inner)
 
-    return factor_cols, n_inner
+    return facet_dims, n_inner
 
 
 # --------------------------------------------------------
@@ -1651,8 +1651,8 @@ def create_plot(
     pi.plot_args = plot_args
 
     # Get list of factor columns (adding question and category if needed)
-    factor_cols_input = list(pp_desc.factor_cols or [])
-    factor_cols, n_inner = _inner_outer_factors(factor_cols_input, pp_desc, plot_meta)
+    facet_dims_input = list(pp_desc.facet_dims or [])
+    facet_dims, n_inner = _inner_outer_facets(facet_dims_input, pp_desc, plot_meta)
 
     # Reorder categories if required
     if pp_desc.sort:
@@ -1666,8 +1666,8 @@ def create_plot(
             # This converts the categorical into numeric values and then sorts by the mean of the value
             # If the sort column IS the first facet, the numeric-scale sort is incoherent -
             # fall through to the plain mean-of-value_col sort below.
-            if plot_meta.sort_numeric_first_facet and cn != factor_cols[0]:
-                f0 = factor_cols[0]
+            if plot_meta.sort_numeric_first_facet and cn != facet_dims[0]:
+                f0 = facet_dims[0]
                 nvals = _get_cat_num_vals(col_meta[f0], pp_desc)
                 cats = col_meta[f0].categories or []
                 cmap = dict(zip(cats, nvals))
@@ -1686,20 +1686,20 @@ def create_plot(
             order = ordervals.sort_values(ascending=ascending).index
             data[cn] = pd.Categorical(data[cn], list(order))
     elif "ordering_value" in data.columns and pp_desc.plot == "maxdiff":
-        if pp_desc.factor_cols:
-            q = pp_desc.factor_cols[0]
+        if pp_desc.facet_dims:
+            q = pp_desc.facet_dims[0]
             order = data.groupby(q, observed=True)["ordering_value"].mean().sort_values(ascending=False).index
             data[q] = pd.Categorical(data[q], list(order))
 
     # Stash the resolved facet split for payload consumers (wire: facet_dims/n_inner)
-    pi.facet_dims = list(factor_cols)
+    pi.facet_dims = list(facet_dims)
     pi.n_inner = n_inner
 
     # Handle internal facets (and translate as needed)
     pi.facets = []
 
     if n_inner > 0:
-        for cn in factor_cols[:n_inner]:
+        for cn in facet_dims[:n_inner]:
             base_meta = col_meta.get(cn, GroupOrColumnMeta())
             fd = FacetMeta(
                 col=cn,
@@ -1720,8 +1720,8 @@ def create_plot(
                     if facet_meta:
                         plot_args[k] = _meta_to_plain(facet_meta).get(k)
 
-        factor_cols = factor_cols[n_inner:]  # Leave rest for external faceting
-    pi.outer_factors = factor_cols
+        facet_dims = facet_dims[n_inner:]  # Leave rest for external faceting
+    pi.outer_factors = facet_dims
 
     if plot_meta.no_faceting and len(pi.outer_factors) > 0:
         return_matrix_of_plots = True
@@ -1941,15 +1941,12 @@ def _apply_publish_mode(plot: AltairChart) -> AltairChart:
     return type(plot).from_dict(spec)
 
 
-def impute_factor_cols(
+def impute_facet_dims(
     pp_desc: PlotDescriptor | Dict[str, Any],
     col_meta: Mapping[str, GroupOrColumnMeta],
     plot_meta: PlotMeta | None = None,
 ) -> List[str]:
-    """Compute the full factor_cols list, including question and res_col as needed.
-
-    Ensures descriptor has sensible defaults for `factor_cols`.
-    """
+    """Compute the full facet_dims list, including question and res_col as needed."""
 
     if isinstance(pp_desc, dict) and "plot" not in pp_desc:
         pp_desc["plot"] = "default"
@@ -1957,7 +1954,7 @@ def impute_factor_cols(
     # Ensure pp_desc is a PlotDescriptor object
     pp_desc = soft_validate(pp_desc, PlotDescriptor)
 
-    factor_cols = list(pp_desc.factor_cols or [])
+    facet_dims = list(pp_desc.facet_dims or [])
 
     # Determine if res is categorical
     res_col = pp_desc.res_col
@@ -1968,28 +1965,32 @@ def impute_factor_cols(
     cat_res = has_categories and convert_res != "continuous"
 
     # Add res_col if we are working with a categorical input (and not converting it to continuous)
-    if cat_res and res_col not in factor_cols:
-        factor_cols.insert(0, res_col)
-    if len(factor_cols) < 1 and not has_q:
+    if cat_res and res_col not in facet_dims:
+        facet_dims.insert(0, res_col)
+    if len(facet_dims) < 1 and not has_q:
         # Create 'question' as a dummy dimension so we have at least one factor
         # (generally required for plotting)
         has_q = True
 
     # If we need to, add question as a factor to list
-    if has_q and "question" not in factor_cols:
+    if has_q and "question" not in facet_dims:
         if cat_res:
-            factor_cols.append("question")  # Put it last for categorical values
+            facet_dims.append("question")  # Put it last for categorical values
         else:
-            factor_cols.insert(
+            facet_dims.insert(
                 0, "question"
             )  # And first for continuous values, as it then often represents the "category"
 
-    # Pass the factor_cols through the same changes done inside plot pipeline to make more explicit what happens
+    # Pass the facet_dims through the same changes done inside plot pipeline to make more explicit what happens
     if plot_meta:
-        factor_cols, _ = _inner_outer_factors(factor_cols, pp_desc, plot_meta)
+        facet_dims, _ = _inner_outer_facets(facet_dims, pp_desc, plot_meta)
 
-    return factor_cols
+    return facet_dims
 
+
+
+# Legacy name kept for external callers
+impute_factor_cols = impute_facet_dims
 
 def e2e_plot(
     pp_desc: Dict[str, Any] | PlotDescriptor,
@@ -2029,8 +2030,8 @@ def e2e_plot(
         raise ValueError(f"Parquet file {data_file} has no data metadata")
 
     if impute:
-        factor_cols = impute_factor_cols(pp_desc, extract_column_meta(data_meta), get_plot_meta(pp_desc.plot))
-        pp_desc = pp_desc.model_copy(update={"factor_cols": factor_cols})
+        facet_dims = impute_facet_dims(pp_desc, extract_column_meta(data_meta), get_plot_meta(pp_desc.plot))
+        pp_desc = pp_desc.model_copy(update={"facet_dims": facet_dims})
 
     if check_match:
         matches = matching_plots(pp_desc, full_df, data_meta, details=True, list_hidden=True)

--- a/salk_toolkit/pp.py
+++ b/salk_toolkit/pp.py
@@ -122,7 +122,8 @@ class PlotInput:
     cat_col: Optional[str] = None
     val_format: str = "%"
     val_range: Optional[Tuple[Optional[float], Optional[float]]] = None
-    filtered_size: float = 0.0
+    filtered_size: float = 0.0  # post-filter weight (the "displayed_n" the plot is based on)
+    total_n: float = 0.0  # pre-filter total weight, so consumers can show "filtered to X%"
     facets: List[FacetMeta] = field(default_factory=list)
     translate: Optional[Callable[[str], str]] = None
     tooltip: List[Any] = field(default_factory=list)
@@ -423,6 +424,7 @@ def get_plot_fn(plot_name: str) -> Callable[..., AltairChart]:
             val_format=cast(str, pparams.get("val_format") or "%"),
             val_range=cast(Optional[Tuple[Optional[float], Optional[float]]], pparams.get("val_range")),
             filtered_size=float(cast(object, pparams.get("filtered_size") or 0.0)),
+            total_n=float(cast(object, pparams.get("total_n") or 0.0)),
             facets=facets_list,
             tooltip=cast(List[Any], pparams.get("tooltip") or []),
             value_range=cast(Optional[Tuple[float, float]], pparams.get("value_range")),
@@ -1093,7 +1095,10 @@ def pp_transform_data(
 
     # Add row id-s and find count - both need to happen before filtering
     full_df = full_df.with_row_index("id")
-    total_n = full_df.select(pl.len()).collect().item()
+    counts = full_df.select(pl.len().alias("n"), pl.col(weight_col).sum().alias("w")).collect()
+    total_n = counts["n"].item()
+    # Prefer the meta-supplied population total; fall back to the pre-filter weight sum
+    total_weight = data_meta.total_size if data_meta.total_size is not None else counts["w"].item()
 
     # For more customized filtering in dashboards
     # Has to be done before downselecting to only needed columns
@@ -1266,6 +1271,7 @@ def pp_transform_data(
     # Aggregate the data into right shape
     pi = _wrangle_data(filtered_df, c_meta, facet_dims, weight_col, pp_desc, n_questions)
 
+    pi.total_n = float(total_weight)
     pi.val_format = val_format
     pi.val_range = val_range  # Currently not used
 
@@ -1988,9 +1994,9 @@ def impute_facet_dims(
     return facet_dims
 
 
-
 # Legacy name kept for external callers
 impute_factor_cols = impute_facet_dims
+
 
 def e2e_plot(
     pp_desc: Dict[str, Any] | PlotDescriptor,

--- a/salk_toolkit/pp.py
+++ b/salk_toolkit/pp.py
@@ -133,6 +133,8 @@ class PlotInput:
     outer_factors: List[str] = field(default_factory=list)
     plot_args: Dict[str, Any] = field(default_factory=dict)
     n_facet_cols: Optional[int] = None  # stashed by create_plot for payload consumers
+    factor_cols: List[str] = field(default_factory=list)  # resolved facet list; outer_factors == factor_cols[n_inner:]
+    n_inner: int = 0  # how many factor_cols the plot consumes as inner facets
     return_df: bool = False  # payload=True plots return the prepared PlotInput instead of a chart
 
     def model_copy(self, *, deep: bool = False, update: dict[str, Any] | None = None) -> "PlotInput":
@@ -1688,6 +1690,10 @@ def create_plot(
             q = pp_desc.factor_cols[0]
             order = data.groupby(q, observed=True)["ordering_value"].mean().sort_values(ascending=False).index
             data[q] = pd.Categorical(data[q], list(order))
+
+    # Stash the resolved facet split for payload consumers (wire: factor_cols/n_inner)
+    pi.factor_cols = list(factor_cols)
+    pi.n_inner = n_inner
 
     # Handle internal facets (and translate as needed)
     pi.facets = []

--- a/salk_toolkit/pp.py
+++ b/salk_toolkit/pp.py
@@ -133,7 +133,7 @@ class PlotInput:
     outer_factors: List[str] = field(default_factory=list)
     plot_args: Dict[str, Any] = field(default_factory=dict)
     n_facet_cols: Optional[int] = None  # stashed by create_plot for payload consumers
-    facet_dims: List[str] = field(default_factory=list)  # resolved facet dimensions; outer_factors == facet_dims[n_inner:]
+    facet_dims: List[str] = field(default_factory=list)  # resolved facets; outer_factors == facet_dims[n_inner:]
     n_inner: int = 0  # how many facet_dims the plot consumes as inner facets
     return_df: bool = False  # payload=True plots return the prepared PlotInput instead of a chart
 

--- a/salk_toolkit/pp.py
+++ b/salk_toolkit/pp.py
@@ -134,7 +134,9 @@ class PlotInput:
     outer_factors: List[str] = field(default_factory=list)
     plot_args: Dict[str, Any] = field(default_factory=dict)
     n_facet_cols: Optional[int] = None  # stashed by create_plot for payload consumers
-    facet_dims: List[str] = field(default_factory=list)  # resolved facets; outer_factors == facet_dims[n_inner:]
+    # Resolved facet split in descriptor vocabulary; outer_factors is the rendered view of
+    # facet_dims[n_inner:] (translated; for >=2 outer facets also reversed and possibly merged)
+    facet_dims: List[str] = field(default_factory=list)
     n_inner: int = 0  # how many facet_dims the plot consumes as inner facets
     return_df: bool = False  # payload=True plots return the prepared PlotInput instead of a chart
 
@@ -1067,7 +1069,7 @@ def pp_transform_data(
 
     # Figure out which columns we actually need
     weight_col = data_meta.weight_col or "row_weights"
-    facet_dims = list(pp_desc.facet_dims).copy()
+    facet_dims = list(pp_desc.facet_dims)
 
     # Ensure weight column is present (fill with 1.0 if not)
     if weight_col not in all_col_names:
@@ -1095,10 +1097,13 @@ def pp_transform_data(
 
     # Add row id-s and find count - both need to happen before filtering
     full_df = full_df.with_row_index("id")
-    counts = full_df.select(pl.len().alias("n"), pl.col(weight_col).sum().alias("w")).collect()
-    total_n = counts["n"].item()
-    # Prefer the meta-supplied population total; fall back to the pre-filter weight sum
-    total_weight = data_meta.total_size if data_meta.total_size is not None else counts["w"].item()
+    # Prefer the meta-supplied population total; only sum the weight column when actually needed
+    if data_meta.total_size is not None:
+        n_rows = full_df.select(pl.len()).collect().item()
+        total_weight = data_meta.total_size
+    else:
+        counts = full_df.select(pl.len().alias("n"), pl.col(weight_col).sum().alias("w")).collect()
+        n_rows, total_weight = counts["n"].item(), counts["w"].item()
 
     # For more customized filtering in dashboards
     # Has to be done before downselecting to only needed columns
@@ -1114,7 +1119,7 @@ def pp_transform_data(
     else:
         filtered_df = df
 
-    # Discretize factor columns that are numeric
+    # Discretize facet dimensions that are numeric
     for c in facet_dims:
         if c in cols and schema[c].is_numeric():
             current_meta = c_meta.get(c)
@@ -1205,8 +1210,8 @@ def pp_transform_data(
     # Compute draws if needed - Nb: also applies if the draws are shared for the group of questions
     if "draw" in cols and pp_desc.res_col in draws_data:
         uid, ndraws = draws_data[pp_desc.res_col]
-        draws = utils.stable_draws(total_n, ndraws, uid)
-        draw_df = pl.DataFrame({"draw": draws, "id": np.arange(0, total_n)})
+        draws = utils.stable_draws(n_rows, ndraws, uid)
+        draw_df = pl.DataFrame({"draw": draws, "id": np.arange(0, n_rows)})
         filtered_df = filtered_df.drop("draw").join(draw_df.lazy(), on=["id"], how="left")
 
     # If res_col is a group of questions, melt i.e. unpivot the questions and handle draws if needed
@@ -1227,9 +1232,9 @@ def pp_transform_data(
                 if c in draws_data:
                     uid, ndraws = draws_data[c]
                     if (uid, ndraws) not in ddf_cache:
-                        draws = utils.stable_draws(total_n, ndraws, uid)
+                        draws = utils.stable_draws(n_rows, ndraws, uid)
                         ddf_cache[(uid, ndraws)] = pl.DataFrame(
-                            {"draw": draws, "question": c, "id": np.arange(0, total_n)}
+                            {"draw": draws, "question": c, "id": np.arange(0, n_rows)}
                         )
                     ddf = ddf_cache[(uid, ndraws)]
                     draw_dfs.append(ddf)
@@ -1269,9 +1274,8 @@ def pp_transform_data(
             c_meta["question"] = question_meta
 
     # Aggregate the data into right shape
-    pi = _wrangle_data(filtered_df, c_meta, facet_dims, weight_col, pp_desc, n_questions)
+    pi = _wrangle_data(filtered_df, c_meta, facet_dims, weight_col, pp_desc, n_questions, float(total_weight))
 
-    pi.total_n = float(total_weight)
     pi.val_format = val_format
     pi.val_range = val_range  # Currently not used
 
@@ -1294,6 +1298,7 @@ def _wrangle_data(
     weight_col: str,
     pp_desc: PlotDescriptor,
     n_questions: int,
+    total_n: float = 0.0,
 ) -> PlotInput:
     """Aggregate filtered data into a structured ``PlotInput`` model for create_plot."""
 
@@ -1305,8 +1310,6 @@ def _wrangle_data(
 
     draws = plot_meta.draws
     data_format = plot_meta.data_format
-
-    # if pp_desc['res_col'] in facet_dims: facet_dims.remove(pp_desc['res_col']) # Res cannot also be a factor
 
     # Determine the groupby dimensions
     gb_dims = facet_dims + (["draw"] if draws else []) + (["id"] if plot_meta.data_format == "raw" else [])
@@ -1457,6 +1460,7 @@ def _wrangle_data(
         value_col=value_col,
         cat_col=cat_col,
         filtered_size=filtered_size,
+        total_n=total_n,
     )
 
 
@@ -1577,7 +1581,7 @@ def _create_tooltip(
     return tooltips, data
 
 
-def _remove_from_internal_fcols(cname: str, facet_dims: List[str], n_inner: int) -> int:
+def _remove_from_inner_facets(cname: str, facet_dims: List[str], n_inner: int) -> int:
     """Shift ``cname`` out of the inner facet slice while preserving order."""
 
     if cname not in facet_dims[:n_inner]:
@@ -1606,8 +1610,8 @@ def _inner_outer_facets(
 
     # If question facet as inner facet for a no_question_facet plot, just move it out
     if plot_meta.no_question_facet:
-        n_inner = _remove_from_internal_fcols("question", facet_dims, n_inner)
-        n_inner = _remove_from_internal_fcols(res_col, facet_dims, n_inner)
+        n_inner = _remove_from_inner_facets("question", facet_dims, n_inner)
+        n_inner = _remove_from_inner_facets(res_col, facet_dims, n_inner)
 
     return facet_dims, n_inner
 
@@ -1656,9 +1660,8 @@ def create_plot(
     plot_args = {**dict(pi.plot_args), **dict(pp_desc.plot_args or {})}
     pi.plot_args = plot_args
 
-    # Get list of factor columns (adding question and category if needed)
-    facet_dims_input = list(pp_desc.facet_dims or [])
-    facet_dims, n_inner = _inner_outer_facets(facet_dims_input, pp_desc, plot_meta)
+    # Get list of facet dimensions (adding question and category if needed)
+    facet_dims, n_inner = _inner_outer_facets(list(pp_desc.facet_dims or []), pp_desc, plot_meta)
 
     # Reorder categories if required
     if pp_desc.sort:

--- a/salk_toolkit/tools/explorer.py
+++ b/salk_toolkit/tools/explorer.py
@@ -177,11 +177,8 @@ def load_file(input_file: str) -> dict[str, object]:
     data_meta = full_meta.data
     mmeta = full_meta.model
     columns = ldf.collect_schema().names()
-    n0 = ldf.select(pl.len()).collect().item()
-    n = data_meta.total_size or n0  # fallback to row count
     return {
         "data": ldf,
-        "total_size": n,
         "data_meta": data_meta,
         "model_meta": mmeta,
         "columns": columns,
@@ -412,7 +409,7 @@ with st.sidebar:  # .expander("Select dimensions"):
     # print(f"localStorage.setItem('args','{json.dumps(args)}');")
     st_js(f"localStorage.setItem('session_state','{json.dumps(dict(st.session_state)).replace("'", "\\'")}');")
 
-    # Make all dimensions explicit now that plot is selected (as that can affect the factor columns)
+    # Make all dimensions explicit now that plot is selected (as that can affect the facet dimensions)
     args["facet_dims"] = impute_facet_dims(args, c_meta, plot_meta)
 
     import pprint
@@ -517,12 +514,8 @@ else:
                 publish_mode=publish_mode,
             )
 
-            # n_questions = pi['data']['question'].nunique() if 'question' in pi['data'] else 1
-            # st.write('Based on %.1f%% of data' %
-            #   (100*pi['n_datapoints']/(len(loaded[ifile]['data_n'])*n_questions)))
-            total_size = loaded[ifile]["total_size"]
-            denominator = float(total_size) if total_size is not None else 1.0
-            st.write("Based on %.1f%% of data" % (100 * pi.filtered_size / denominator))
+            if pi.total_n:
+                st.write("Based on %.1f%% of data" % (100 * pi.filtered_size / pi.total_n))
 
             if i == 0 and st.session_state.get("custom_spec"):
                 custom_spec = deepcopy(st.session_state["custom_spec"])

--- a/salk_toolkit/tools/explorer.py
+++ b/salk_toolkit/tools/explorer.py
@@ -73,7 +73,7 @@ with st.spinner("Loading libraries.."):
         cont_transform_options,
         create_plot,
         get_plot_meta,
-        impute_factor_cols,
+        impute_facet_dims,
         matching_plots,
         pp_transform_data,
     )
@@ -287,14 +287,14 @@ with st.sidebar:  # .expander("Select dimensions"):
     modifiers = c_meta[obs_name].modifiers
     all_dims = list(modifiers) + all_dims
 
-    facet_dims = all_dims
+    facetable_dims = all_dims
     if len(input_files) > 1:
-        facet_dims = ["input_file"] + facet_dims
+        facetable_dims = ["input_file"] + facetable_dims
 
-    args["factor_cols"] = facet_ui(facet_dims, two=True)
+    args["facet_dims"] = facet_ui(facetable_dims, two=True)
 
     # Check if any facet dims match observation dim or each other
-    if len(set(args["factor_cols"] + [obs_name])) != len(args["factor_cols"]) + 1:
+    if len(set(args["facet_dims"] + [obs_name])) != len(args["facet_dims"]) + 1:
         st.markdown("""Please choose facets different from observation dimension""")
         st.stop()
 
@@ -302,7 +302,7 @@ with st.sidebar:  # .expander("Select dimensions"):
     sort = st.toggle("Sort facets", False, key="sort")
 
     # Make all dimensions explicit
-    args["factor_cols"] = impute_factor_cols(args, c_meta)
+    args["facet_dims"] = impute_facet_dims(args, c_meta)
 
     # Plot type
     matching = matching_plots(args, first_data, first_data_meta)
@@ -352,7 +352,7 @@ with st.sidebar:  # .expander("Select dimensions"):
             if agg_fn != "mean":
                 args["agg_fn"] = agg_fn
 
-        sortable = args["factor_cols"]
+        sortable = args["facet_dims"]
         if plot_meta_dict.get("sort_numeric_first_facet"):
             sortable = sortable[1:]
         if sort and len(sortable) > 0:
@@ -362,17 +362,17 @@ with st.sidebar:  # .expander("Select dimensions"):
             args["sort"] = {sort_facet: ascending}
 
         qpos = st.selectbox("Question position", ["Auto", 1, 2, 3], key="q_pos")
-        if "question" in args["factor_cols"] and qpos != "Auto":
-            args["factor_cols"] = [c for c in args["factor_cols"] if c != "question"]
-            args["factor_cols"].insert(int(qpos) - 1, "question")
+        if "question" in args["facet_dims"] and qpos != "Auto":
+            args["facet_dims"] = [c for c in args["facet_dims"] if c != "question"]
+            args["facet_dims"].insert(int(qpos) - 1, "question")
 
         # Drop a now-incoherent sort: if the sort target ended up as the first facet
         # and the plot uses sort_numeric_first_facet, the numeric-scale sort is meaningless.
         if (
             plot_meta_dict.get("sort_numeric_first_facet")
             and args.get("sort")
-            and args["factor_cols"]
-            and next(iter(args["sort"])) == args["factor_cols"][0]
+            and args["facet_dims"]
+            and next(iter(args["sort"])) == args["facet_dims"][0]
         ):
             args.pop("sort", None)
 
@@ -413,7 +413,7 @@ with st.sidebar:  # .expander("Select dimensions"):
     st_js(f"localStorage.setItem('session_state','{json.dumps(dict(st.session_state)).replace("'", "\\'")}');")
 
     # Make all dimensions explicit now that plot is selected (as that can affect the factor columns)
-    args["factor_cols"] = impute_factor_cols(args, c_meta, plot_meta)
+    args["facet_dims"] = impute_facet_dims(args, c_meta, plot_meta)
 
     import pprint
 
@@ -435,7 +435,7 @@ with st.sidebar:  # .expander("Select dimensions"):
 matrix_form = False  # (args['plot'] == 'geoplot')
 
 # Determine if one of the facets is input_file
-input_files_facet = "input_file" in args.get("factor_cols", [])
+input_files_facet = "input_file" in args.get("facet_dims", [])
 
 # Create columns, one per input file
 if not input_files_facet:
@@ -454,7 +454,7 @@ elif input_files_facet:
         df, fargs = loaded[ifile]["data"], args.copy()
         ifile_cols = list(loaded[ifile]["columns"])  # type: ignore[arg-type]
         fargs["filter"] = {k: v for k, v in fargs["filter"].items() if k in ifile_cols or k in q_groups}
-        fargs["factor_cols"] = [f for f in fargs["factor_cols"] if f != "input_file"]
+        fargs["facet_dims"] = [f for f in fargs["facet_dims"] if f != "input_file"]
         ppd = soft_validate(fargs, PlotDescriptor)
         pi = pp_transform_data(df, raw_first_data_meta, ppd)
         dfs.append(pi.data)
@@ -584,7 +584,7 @@ else:
                     if st.button("Import Spec", width="stretch"):
                         _import_modal()
 
-                    name = f"{args['res_col']}_{'_'.join(args['factor_cols']) if args['factor_cols'] else 'all'}"
+                    name = f"{args['res_col']}_{'_'.join(args['facet_dims']) if args['facet_dims'] else 'all'}"
                     chart_source = (
                         deepcopy(st.session_state["custom_spec"]) if st.session_state.get("custom_spec") else plot
                     )

--- a/salk_toolkit/tools/explorer.py
+++ b/salk_toolkit/tools/explorer.py
@@ -514,8 +514,8 @@ else:
                 publish_mode=publish_mode,
             )
 
-            if pi.total_n:
-                st.write("Based on %.1f%% of data" % (100 * pi.filtered_size / pi.total_n))
+            if pi.total_size:
+                st.write("Based on %.1f%% of data" % (100 * pi.filtered_size / pi.total_size))
 
             if i == 0 and st.session_state.get("custom_spec"):
                 custom_spec = deepcopy(st.session_state["custom_spec"])

--- a/salk_toolkit/validation.py
+++ b/salk_toolkit/validation.py
@@ -62,6 +62,7 @@ from typing import (
     TypeAlias,
 )
 from pydantic import (
+    AliasChoices,
     BaseModel,
     ConfigDict,
     Field,
@@ -755,7 +756,8 @@ class PlotDescriptor(PBase):
     # Main parameters
     plot: str  # Registered plot type (see `salk_toolkit.plots`)
     res_col: str  # Response column or question block name to visualise
-    factor_cols: List[str] = []  # Facet dimensions applied to the plot
+    # Facet dimensions applied to the plot ("factor_cols" accepted as a legacy key)
+    facet_dims: List[str] = Field(default=[], validation_alias=AliasChoices("facet_dims", "factor_cols"))
     filter: FilterSpec = {}  # Column filters applied before aggregation
 
     # Plotting choices

--- a/tests/test_plot_payload.py
+++ b/tests/test_plot_payload.py
@@ -1105,6 +1105,16 @@ def test_payload_echoes_resolved_facet_dims(small_pi_fixture, ppd_columns):
     assert pl["facet_dims"][pl["n_inner"] :] == pl["outer_factors"]
 
 
+def test_two_outer_facets_reverse_outer_factors(small_pi_fixture, ppd_two_factors):
+    """>=2 outer facets: outer_factors is the rendered (reversed) view, not facet_dims[n_inner:].
+    Consumers wanting descriptor order must read facet_dims/n_inner."""
+
+    pi = pp.create_plot(small_pi_fixture, ppd_two_factors, dry_run=True, escape_labels=False)
+    assert pi.facet_dims == ["group.a", "group.b"]
+    assert pi.n_inner == 0
+    assert pi.outer_factors == ["group.b", "group.a"]
+
+
 def test_payload_factor_split_counts_inner_facets(likert_cell_pi_and_ppd):
     """An inner (plot-consumed) facet is IN facet_dims but NOT in outer_factors."""
 

--- a/tests/test_plot_payload.py
+++ b/tests/test_plot_payload.py
@@ -116,14 +116,14 @@ def test_payload_shape_columns(small_pi_fixture, ppd_columns):
 
 
 def test_payload_echoes_filter_weights(small_pi_fixture, ppd_columns):
-    """The payload carries pre-filter (`total_n`) and post-filter (`filtered_size`) weight
+    """The payload carries pre-filter (`total_size`) and post-filter (`filtered_size`) weight
     so the frontend can render "filtered to X%"."""
 
     pi = small_pi_fixture
-    pi.total_n = 100.0
+    pi.total_size = 100.0
     pi.filtered_size = 40.0
     pl = pp.create_plot_payload(pi, ppd_columns)
-    assert pl["total_n"] == 100.0
+    assert pl["total_size"] == 100.0
     assert pl["filtered_size"] == 40.0
 
 

--- a/tests/test_plot_payload.py
+++ b/tests/test_plot_payload.py
@@ -116,8 +116,8 @@ def test_payload_shape_columns(small_pi_fixture, ppd_columns):
 
 
 def test_payload_uncolored_facet_colors_stay_none(barbell_cell_pi_and_ppd):
-    """A facet with no metadata colors carries None (renderer applies its own default,
-    matching the spec path — dms#40 parity finding); explicit colors stay."""
+    """A facet with no metadata colors carries None (the renderer owns the default
+    scheme); explicit colors stay."""
 
     pi, ppd = barbell_cell_pi_and_ppd
     pl = pp.create_plot_payload(pi, ppd)
@@ -825,8 +825,7 @@ def test_payload_geobest_smoke(geobest_cell_pi_and_ppd):
 
 
 def test_payload_geobest_null_colors_smoke(geobest_cell_pi_and_ppd):
-    """An uncolored winner facet stays None; renderers own the fallback (the dms
-    frontend covers this exact case — its plotDataGeobestNullColors fixture)."""
+    """An uncolored winner facet stays None; the renderer owns the fallback."""
 
     pi, ppd = geobest_cell_pi_and_ppd
     pi.col_meta["candidate"] = GroupOrColumnMeta(categories=["Alice", "Bob"])

--- a/tests/test_plot_payload.py
+++ b/tests/test_plot_payload.py
@@ -115,17 +115,15 @@ def test_payload_shape_columns(small_pi_fixture, ppd_columns):
         assert f["colors"] is None or all(isinstance(c, str) for c in f["colors"].values())
 
 
-def test_payload_synthesizes_default_palette_for_uncolored_facet(barbell_cell_pi_and_ppd):
-    """A facet with no metadata colors gets salk's default palette as plain hex; explicit colors stay."""
-
-    from salk_toolkit.utils import altair_default_config
+def test_payload_uncolored_facet_colors_stay_none(barbell_cell_pi_and_ppd):
+    """A facet with no metadata colors carries None (renderer applies its own default,
+    matching the spec path — dms#40 parity finding); explicit colors stay."""
 
     pi, ppd = barbell_cell_pi_and_ppd
     pl = pp.create_plot_payload(pi, ppd)
-    palette = altair_default_config["range"]["category"]
 
     question = next(f for f in pl["facets"] if f["col"] == "question")
-    assert question["colors"] == {"Q1": palette[0], "Q2": palette[1], "Q3": palette[2]}
+    assert question["colors"] is None
 
     group = next(f for f in pl["facets"] if f["col"] == "group")
     assert group["colors"] == {"Group A": "#c00000", "Group B": "#00c000"}
@@ -827,17 +825,15 @@ def test_payload_geobest_smoke(geobest_cell_pi_and_ppd):
 
 
 def test_payload_geobest_null_colors_smoke(geobest_cell_pi_and_ppd):
-    """An uncolored winner facet resolves to salk's default palette as plain hex, not None."""
-
-    from salk_toolkit.utils import altair_default_config
+    """An uncolored winner facet stays None; renderers own the fallback (the dms
+    frontend covers this exact case — its plotDataGeobestNullColors fixture)."""
 
     pi, ppd = geobest_cell_pi_and_ppd
     pi.col_meta["candidate"] = GroupOrColumnMeta(categories=["Alice", "Bob"])
 
     pl = pp.create_plot_payload(pi, ppd)
-    palette = altair_default_config["range"]["category"]
     assert pl["facets"][0]["col"] == "candidate"
-    assert pl["facets"][0]["colors"] == {"Alice": palette[0], "Bob": palette[1]}
+    assert pl["facets"][0]["colors"] is None
 
 
 @pytest.fixture

--- a/tests/test_plot_payload.py
+++ b/tests/test_plot_payload.py
@@ -1085,3 +1085,53 @@ def test_payload_coalition_applet_smoke(election_pi_and_ppd):
     for d, m in zip(cell["data"]["draw"], cell["data"]["mandates"]):
         per_draw[d] = per_draw.get(d, 0) + m
     assert all(v == 7 for v in per_draw.values())
+
+
+def test_payload_echoes_resolved_factor_split(small_pi_fixture, ppd_columns):
+    """factor_cols = the resolved facet list; n_inner splits it so that
+    outer_factors == factor_cols[n_inner:] (the invariant payload consumers rely on)."""
+
+    pl = pp.create_plot_payload(small_pi_fixture, ppd_columns)
+    assert pl["factor_cols"] == ["group.a", "group.b"]
+    assert isinstance(pl["n_inner"], int)
+    assert pl["factor_cols"][pl["n_inner"] :] == pl["outer_factors"]
+
+
+def test_payload_factor_split_counts_inner_facets(likert_cell_pi_and_ppd):
+    """An inner (plot-consumed) facet is IN factor_cols but NOT in outer_factors."""
+
+    pi, ppd = likert_cell_pi_and_ppd
+    pl = pp.create_plot_payload(pi, ppd)
+    assert "agree" in pl["factor_cols"]
+    assert pl["outer_factors"] == []
+    assert pl["n_inner"] == len(pl["factor_cols"])
+    assert pl["factor_cols"][pl["n_inner"] :] == pl["outer_factors"]
+
+
+def test_payload_carries_per_cell_scale_for_faceted_geo(geoplot_cell_pi_and_ppd):
+    """Faceted geo: every cell carries its own colour scale (stops + domain) — the
+    per-cell info toGeoFacetOption used to scrape from each cell's spec."""
+
+    pi, ppd = geoplot_cell_pi_and_ppd
+    regions = ["Harju", "Tartu", "Parnu"]
+    parties = ["P1", "P2"]
+    rng = np.random.default_rng(7)
+    data = pd.DataFrame(
+        {
+            "region": pd.Categorical(regions * 2, categories=regions),
+            "party": pd.Categorical(np.repeat(parties, len(regions)), categories=parties),
+            "score": rng.uniform(-1, 1, len(regions) * 2),
+        }
+    )
+    party_meta = GroupOrColumnMeta(categories=parties)
+    pi = pi.model_copy(update={"data": data, "col_meta": {**pi.col_meta, "party": party_meta}})
+    ppd = ppd.model_copy(update={"factor_cols": ["region", "party"]})
+
+    pl = pp.create_plot_payload(pi, ppd)
+    cells = [c for row in pl["cells"] for c in row]
+    assert len(cells) == 2  # one per party
+    for c in cells:
+        assert isinstance(c.get("scale"), dict)
+        assert c["scale"]["stops"] and len(c["scale"]["domain"]) >= 2
+    # top-level scale stays for back-compat (first cell's)
+    assert pl["scale"] == cells[0]["scale"]

--- a/tests/test_plot_payload.py
+++ b/tests/test_plot_payload.py
@@ -1109,8 +1109,7 @@ def test_payload_factor_split_counts_inner_facets(likert_cell_pi_and_ppd):
 
 
 def test_payload_carries_per_cell_scale_for_faceted_geo(geoplot_cell_pi_and_ppd):
-    """Faceted geo: every cell carries its own colour scale (stops + domain) — the
-    per-cell info toGeoFacetOption used to scrape from each cell's spec."""
+    """Faceted geo: every cell carries its own colour scale (stops + domain)."""
 
     pi, ppd = geoplot_cell_pi_and_ppd
     regions = ["Harju", "Tartu", "Parnu"]

--- a/tests/test_plot_payload.py
+++ b/tests/test_plot_payload.py
@@ -72,7 +72,7 @@ def ppd_two_factors(registered_two_factor_plot):
     return PlotDescriptor(
         plot=registered_two_factor_plot,
         res_col="score",
-        factor_cols=["group.a", "group.b"],
+        facet_dims=["group.a", "group.b"],
     )
 
 
@@ -99,7 +99,7 @@ def test_dry_run_escape_labels_true_escapes_outer_factors(small_pi_fixture, ppd_
 def ppd_columns():
     """A PlotDescriptor targeting the real `columns` plot."""
 
-    return PlotDescriptor(plot="columns", res_col="score", factor_cols=["group.a", "group.b"])
+    return PlotDescriptor(plot="columns", res_col="score", facet_dims=["group.a", "group.b"])
 
 
 def test_payload_shape_columns(small_pi_fixture, ppd_columns):
@@ -142,7 +142,7 @@ def test_payload_fallback_covers_non_payload_plot(small_pi_fixture):
 
     try:
         assert pp.get_plot_meta("__test_fallback_plot").payload is False
-        ppd = PlotDescriptor(plot="__test_fallback_plot", res_col="score", factor_cols=["group.a", "group.b"])
+        ppd = PlotDescriptor(plot="__test_fallback_plot", res_col="score", facet_dims=["group.a", "group.b"])
         pl = pp.create_plot_payload(small_pi_fixture, ppd)
         # every cell carries the frame pulled off the chart's `.data`
         for row in pl["cells"]:
@@ -207,7 +207,7 @@ def ppd_mutating_two_factors(registered_mutating_two_factor_plot):
     ppd = PlotDescriptor(
         plot=plot_name,
         res_col="score",
-        factor_cols=["group.a", "group.b"],
+        facet_dims=["group.a", "group.b"],
         internal_facet=1,
     )
     return ppd, seen_n_facets
@@ -269,7 +269,7 @@ def likert_cell_pi_and_ppd():
     )
     col_meta = {"agree": GroupOrColumnMeta(categories=cats, ordered=True, likert=True, neutral_middle="Neutral")}
     pi = PlotInput(data=data, col_meta=col_meta, value_col="share")
-    ppd = PlotDescriptor(plot="likert_bars", res_col="share", factor_cols=["agree"], internal_facet=True)
+    ppd = PlotDescriptor(plot="likert_bars", res_col="share", facet_dims=["agree"], internal_facet=True)
     return pi, ppd
 
 
@@ -322,7 +322,7 @@ def test_payload_likert_bars_faceted_no_crash():
         "gender": GroupOrColumnMeta(categories=["Male", "Female"]),
     }
     pi = PlotInput(data=data, col_meta=col_meta, value_col="share")
-    ppd = PlotDescriptor(plot="likert_bars", res_col="share", factor_cols=["agree", "gender"])
+    ppd = PlotDescriptor(plot="likert_bars", res_col="share", facet_dims=["agree", "gender"])
 
     pl = pp.create_plot_payload(pi, ppd)
 
@@ -350,7 +350,7 @@ def matrix_cell_pi_and_ppd():
         }
     )
     pi = PlotInput(data=data, col_meta={}, value_col="val")
-    ppd = PlotDescriptor(plot="matrix", res_col="val", factor_cols=["row", "col"], internal_facet=True)
+    ppd = PlotDescriptor(plot="matrix", res_col="val", facet_dims=["row", "col"], internal_facet=True)
     return pi, ppd
 
 
@@ -398,7 +398,7 @@ def boxplot_cell_pi_and_ppd():
         )
     }
     pi = PlotInput(data=data, col_meta=col_meta, value_col="score")
-    ppd = PlotDescriptor(plot="boxplots", res_col="score", factor_cols=["group"], internal_facet=True)
+    ppd = PlotDescriptor(plot="boxplots", res_col="score", facet_dims=["group"], internal_facet=True)
     return pi, ppd
 
 
@@ -448,7 +448,7 @@ def marimekko_cell_pi_and_ppd():
         }
     )
     pi = PlotInput(data=data, col_meta={}, value_col="val")
-    ppd = PlotDescriptor(plot="marimekko", res_col="val", factor_cols=["row", "col"], internal_facet=True)
+    ppd = PlotDescriptor(plot="marimekko", res_col="val", facet_dims=["row", "col"], internal_facet=True)
     return pi, ppd
 
 
@@ -490,7 +490,7 @@ def line_cell_pi_and_ppd():
     )
     col_meta = {"level": GroupOrColumnMeta(categories=cats, ordered=True)}
     pi = PlotInput(data=data, col_meta=col_meta, value_col="share")
-    ppd = PlotDescriptor(plot="line", res_col="share", factor_cols=["level"], internal_facet=True)
+    ppd = PlotDescriptor(plot="line", res_col="share", facet_dims=["level"], internal_facet=True)
     return pi, ppd
 
 
@@ -512,7 +512,7 @@ def lines_cell_pi_and_ppd():
         "stage": GroupOrColumnMeta(categories=stages, ordered=True),
     }
     pi = PlotInput(data=data, col_meta=col_meta, value_col="share")
-    ppd = PlotDescriptor(plot="lines", res_col="share", factor_cols=["group", "stage"], internal_facet=True)
+    ppd = PlotDescriptor(plot="lines", res_col="share", facet_dims=["group", "stage"], internal_facet=True)
     return pi, ppd
 
 
@@ -572,7 +572,7 @@ def density_cell_pi_and_ppd():
     )
     col_meta = {"group": GroupOrColumnMeta(categories=cats)}
     pi = PlotInput(data=data, col_meta=col_meta, value_col="score")
-    ppd = PlotDescriptor(plot="density-raw", res_col="score", factor_cols=["group"], internal_facet=True)
+    ppd = PlotDescriptor(plot="density-raw", res_col="score", facet_dims=["group"], internal_facet=True)
     return pi, ppd
 
 
@@ -660,7 +660,7 @@ def test_density_categorical_input_typed_error():
     cats = ["Low", "Mid", "High"]
     data = pd.DataFrame({"answer": pd.Categorical(cats * 4, categories=cats, ordered=True)})
     pi = PlotInput(data=data, col_meta={}, value_col="answer")
-    ppd = PlotDescriptor(plot="density-raw", res_col="answer", factor_cols=[])
+    ppd = PlotDescriptor(plot="density-raw", res_col="answer", facet_dims=[])
 
     with pytest.raises(ValueError, match="continuous"):
         pp.create_plot(pi, ppd, width=400)
@@ -687,7 +687,7 @@ def geoplot_cell_pi_and_ppd():
         )
     }
     pi = PlotInput(data=data, col_meta=col_meta, value_col="score")
-    ppd = PlotDescriptor(plot="geoplot", res_col="score", factor_cols=["region"], internal_facet=True)
+    ppd = PlotDescriptor(plot="geoplot", res_col="score", facet_dims=["region"], internal_facet=True)
     return pi, ppd
 
 
@@ -764,7 +764,7 @@ def geobest_cell_pi_and_ppd():
         ),
     }
     pi = PlotInput(data=data, col_meta=col_meta, value_col="score")
-    ppd = PlotDescriptor(plot="geobest", res_col="score", factor_cols=["candidate", "region"], internal_facet=True)
+    ppd = PlotDescriptor(plot="geobest", res_col="score", facet_dims=["candidate", "region"], internal_facet=True)
     return pi, ppd
 
 
@@ -859,7 +859,7 @@ def barbell_cell_pi_and_ppd():
         "group": GroupOrColumnMeta(categories=groups, colors={"Group A": "#c00000", "Group B": "#00c000"}),
     }
     pi = PlotInput(data=data, col_meta=col_meta, value_col="score")
-    ppd = PlotDescriptor(plot="barbell", res_col="score", factor_cols=["question", "group"], internal_facet=True)
+    ppd = PlotDescriptor(plot="barbell", res_col="score", facet_dims=["question", "group"], internal_facet=True)
     return pi, ppd
 
 
@@ -912,7 +912,7 @@ def maxdiff_cell_pi_and_ppd():
         }
     )
     pi = PlotInput(data=data, col_meta={}, value_col="score")
-    ppd = PlotDescriptor(plot="maxdiff", res_col="score", factor_cols=["topic"], internal_facet=True)
+    ppd = PlotDescriptor(plot="maxdiff", res_col="score", facet_dims=["topic"], internal_facet=True)
     return pi, ppd
 
 
@@ -979,14 +979,14 @@ def test_matching_plots_maxdiff_requires_continuous_res_col():
     )
 
     categorical_matches = matching_plots(
-        {"res_col": "party", "factor_cols": ["topic"], "plot": "maxdiff"}, df, data_meta, details=True
+        {"res_col": "party", "facet_dims": ["topic"], "plot": "maxdiff"}, df, data_meta, details=True
     )
     priority, reasons = categorical_matches["maxdiff"]
     assert priority < 0
     assert "continuous_only" in reasons
 
     continuous_matches = matching_plots(
-        {"res_col": "score", "factor_cols": ["topic"], "plot": "maxdiff"}, df, data_meta, details=True
+        {"res_col": "score", "facet_dims": ["topic"], "plot": "maxdiff"}, df, data_meta, details=True
     )
     priority2, reasons2 = continuous_matches["maxdiff"]
     assert priority2 >= 0
@@ -1023,7 +1023,7 @@ def election_pi_and_ppd():
         ),
     }
     pi = PlotInput(data=data, col_meta=col_meta, value_col="support")
-    ppd = PlotDescriptor(plot="mandate_plot", res_col="support", factor_cols=["party", "district"], internal_facet=True)
+    ppd = PlotDescriptor(plot="mandate_plot", res_col="support", facet_dims=["party", "district"], internal_facet=True)
     return pi, ppd
 
 
@@ -1124,7 +1124,7 @@ def test_payload_carries_per_cell_scale_for_faceted_geo(geoplot_cell_pi_and_ppd)
     )
     party_meta = GroupOrColumnMeta(categories=parties)
     pi = pi.model_copy(update={"data": data, "col_meta": {**pi.col_meta, "party": party_meta}})
-    ppd = ppd.model_copy(update={"factor_cols": ["region", "party"]})
+    ppd = ppd.model_copy(update={"facet_dims": ["region", "party"]})
 
     pl = pp.create_plot_payload(pi, ppd)
     cells = [c for row in pl["cells"] for c in row]

--- a/tests/test_plot_payload.py
+++ b/tests/test_plot_payload.py
@@ -1087,25 +1087,25 @@ def test_payload_coalition_applet_smoke(election_pi_and_ppd):
     assert all(v == 7 for v in per_draw.values())
 
 
-def test_payload_echoes_resolved_factor_split(small_pi_fixture, ppd_columns):
-    """factor_cols = the resolved facet list; n_inner splits it so that
-    outer_factors == factor_cols[n_inner:] (the invariant payload consumers rely on)."""
+def test_payload_echoes_resolved_facet_dims(small_pi_fixture, ppd_columns):
+    """facet_dims = the resolved facet dimensions (matching /dimensions vocabulary);
+    n_inner splits it so that outer_factors == facet_dims[n_inner:]."""
 
     pl = pp.create_plot_payload(small_pi_fixture, ppd_columns)
-    assert pl["factor_cols"] == ["group.a", "group.b"]
+    assert pl["facet_dims"] == ["group.a", "group.b"]
     assert isinstance(pl["n_inner"], int)
-    assert pl["factor_cols"][pl["n_inner"] :] == pl["outer_factors"]
+    assert pl["facet_dims"][pl["n_inner"] :] == pl["outer_factors"]
 
 
 def test_payload_factor_split_counts_inner_facets(likert_cell_pi_and_ppd):
-    """An inner (plot-consumed) facet is IN factor_cols but NOT in outer_factors."""
+    """An inner (plot-consumed) facet is IN facet_dims but NOT in outer_factors."""
 
     pi, ppd = likert_cell_pi_and_ppd
     pl = pp.create_plot_payload(pi, ppd)
-    assert "agree" in pl["factor_cols"]
+    assert "agree" in pl["facet_dims"]
     assert pl["outer_factors"] == []
-    assert pl["n_inner"] == len(pl["factor_cols"])
-    assert pl["factor_cols"][pl["n_inner"] :] == pl["outer_factors"]
+    assert pl["n_inner"] == len(pl["facet_dims"])
+    assert pl["facet_dims"][pl["n_inner"] :] == pl["outer_factors"]
 
 
 def test_payload_carries_per_cell_scale_for_faceted_geo(geoplot_cell_pi_and_ppd):

--- a/tests/test_plot_payload.py
+++ b/tests/test_plot_payload.py
@@ -115,6 +115,18 @@ def test_payload_shape_columns(small_pi_fixture, ppd_columns):
         assert f["colors"] is None or all(isinstance(c, str) for c in f["colors"].values())
 
 
+def test_payload_echoes_filter_weights(small_pi_fixture, ppd_columns):
+    """The payload carries pre-filter (`total_n`) and post-filter (`filtered_size`) weight
+    so the frontend can render "filtered to X%"."""
+
+    pi = small_pi_fixture
+    pi.total_n = 100.0
+    pi.filtered_size = 40.0
+    pl = pp.create_plot_payload(pi, ppd_columns)
+    assert pl["total_n"] == 100.0
+    assert pl["filtered_size"] == 40.0
+
+
 def test_payload_uncolored_facet_colors_stay_none(barbell_cell_pi_and_ppd):
     """A facet with no metadata colors carries None (the renderer owns the default
     scheme); explicit colors stay."""

--- a/tests/test_plot_payload.py
+++ b/tests/test_plot_payload.py
@@ -1096,7 +1096,8 @@ def test_payload_coalition_applet_smoke(election_pi_and_ppd):
 
 def test_payload_echoes_resolved_facet_dims(small_pi_fixture, ppd_columns):
     """facet_dims = the resolved facet dimensions (matching /dimensions vocabulary);
-    n_inner splits it so that outer_factors == facet_dims[n_inner:]."""
+    n_inner splits it. outer_factors is the rendered view of facet_dims[n_inner:] --
+    identical here (<=1 outer facet, no translate); >=2 outer facets get reversed/merged."""
 
     pl = pp.create_plot_payload(small_pi_fixture, ppd_columns)
     assert pl["facet_dims"] == ["group.a", "group.b"]
@@ -1112,7 +1113,6 @@ def test_payload_factor_split_counts_inner_facets(likert_cell_pi_and_ppd):
     assert "agree" in pl["facet_dims"]
     assert pl["outer_factors"] == []
     assert pl["n_inner"] == len(pl["facet_dims"])
-    assert pl["facet_dims"][pl["n_inner"] :] == pl["outer_factors"]
 
 
 def test_payload_carries_per_cell_scale_for_faceted_geo(geoplot_cell_pi_and_ppd):

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -268,7 +268,7 @@ class TestPlots:
         """Test basic boxplots."""
         config = {
             "res_col": "party_preference",
-            "factor_cols": ["age_group"],
+            "facet_dims": ["age_group"],
             "filter": {},
             "plot": "boxplots",
             "internal_facet": True,
@@ -279,7 +279,7 @@ class TestPlots:
         """Test raw boxplots."""
         config = {
             "res_col": "EKRE",
-            "factor_cols": ["age_group"],
+            "facet_dims": ["age_group"],
             "filter": {},
             "plot": "boxplots-raw",
             "internal_facet": True,
@@ -290,7 +290,7 @@ class TestPlots:
         """Test basic column plots."""
         config = {
             "res_col": "e-valimised",
-            "factor_cols": ["nationality"],
+            "facet_dims": ["nationality"],
             "filter": {},
             "plot": "columns",
             "internal_facet": True,
@@ -301,7 +301,7 @@ class TestPlots:
         """Test column plots with thermometer data."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["nationality"],
+            "facet_dims": ["nationality"],
             "filter": {},
             "plot": "columns",
             "internal_facet": True,
@@ -312,7 +312,7 @@ class TestPlots:
         """Test column plot with custom aggregation and sorting."""
         config = {
             "res_col": "EKRE",
-            "factor_cols": ["nationality"],
+            "facet_dims": ["nationality"],
             "filter": {},
             "plot": "columns",
             "internal_facet": True,
@@ -326,7 +326,7 @@ class TestPlots:
         """Test stacked column plots."""
         config = {
             "res_col": "party_preference",
-            "factor_cols": ["EKRE"],
+            "facet_dims": ["EKRE"],
             "internal_facet": True,
             "plot": "stacked_columns",
             "plot_args": {"normalized": False},
@@ -338,7 +338,7 @@ class TestPlots:
         """Test difference column plots."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["age_group"],
+            "facet_dims": ["age_group"],
             "filter": {"age_group": [None, "25-34", "35-44"]},
             "plot": "diff_columns",
             "internal_facet": True,
@@ -350,7 +350,7 @@ class TestPlots:
         """Test mass plot."""
         config = {
             "res_col": "trust",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "massplot",
             "internal_facet": True,
@@ -362,7 +362,7 @@ class TestPlots:
         """Test basic Likert bars."""
         config = {
             "res_col": "trust",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "likert_bars",
             "internal_facet": True,
@@ -373,7 +373,7 @@ class TestPlots:
         """Test Likert bars with no factor columns."""
         config = {
             "res_col": "valitsus",
-            "factor_cols": [],
+            "facet_dims": [],
             "filter": {},
             "plot": "likert_bars",
             "internal_facet": True,
@@ -384,7 +384,7 @@ class TestPlots:
         """Test raw density plot with stacking."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "density-raw",
             "plot_args": {"stacked": True},
@@ -396,7 +396,7 @@ class TestPlots:
         """Test raw violin plot."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "violin-raw",
             "sort": {"question": False},
@@ -408,7 +408,7 @@ class TestPlots:
         """Test basic matrix plot."""
         config = {
             "res_col": "party_preference",
-            "factor_cols": ["age_group"],
+            "facet_dims": ["age_group"],
             "filter": {},
             "plot": "matrix",
             "internal_facet": True,
@@ -419,7 +419,7 @@ class TestPlots:
         """Test matrix plot with thermometer data."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "matrix",
             "internal_facet": True,
@@ -430,7 +430,7 @@ class TestPlots:
         """Test matrix plot with reordering."""
         config = {
             "res_col": "issues",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "matrix",
             "plot_args": {"reorder": True},
@@ -444,7 +444,7 @@ class TestPlots:
         """Test correlation matrix plot."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": [],
+            "facet_dims": [],
             "filter": {},
             "plot": "corr_matrix",
             "internal_facet": True,
@@ -455,7 +455,7 @@ class TestPlots:
         """Test line plot with smoothing."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["education"],
+            "facet_dims": ["education"],
             "filter": {},
             "plot": "lines",
             "internal_facet": True,
@@ -468,7 +468,7 @@ class TestPlots:
         """Test line plot with smoothing."""
         config = {
             "res_col": "party_preference",
-            "factor_cols": ["td"],
+            "facet_dims": ["td"],
             "filter": {},
             "plot": "lines",
             "internal_facet": True,
@@ -479,7 +479,7 @@ class TestPlots:
         """Test HDI line plot."""
         config = {
             "res_col": "party_preference",
-            "factor_cols": ["age_group", "nationality"],
+            "facet_dims": ["age_group", "nationality"],
             "filter": {},
             "plot": "lines_hdi",
             "internal_facet": True,
@@ -490,7 +490,7 @@ class TestPlots:
         """Test smooth area plot."""
         config = {
             "res_col": "party_preference",
-            "factor_cols": ["education", "gender"],
+            "facet_dims": ["education", "gender"],
             "filter": {},
             "plot": "area_smooth",
             "internal_facet": True,
@@ -501,7 +501,7 @@ class TestPlots:
         """Test Likert radicalization/polarization plot."""
         config = {
             "res_col": "referendum",
-            "factor_cols": ["electoral_district"],
+            "facet_dims": ["electoral_district"],
             "internal_facet": True,
             "plot": "likert_rad_pol",
             "filter": {},
@@ -513,7 +513,7 @@ class TestPlots:
         """Test barbell plot."""
         config = {
             "res_col": "trust",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "barbell",
             "internal_facet": True,
@@ -528,7 +528,7 @@ class TestPlots:
 
         config = {
             "res_col": "EKRE",
-            "factor_cols": ["electoral_district"],
+            "facet_dims": ["electoral_district"],
             "filter": {},
             "plot": "geoplot",
             "internal_facet": True,
@@ -547,7 +547,7 @@ class TestPlots:
             pytest.skip("Data metadata not available for geoplot test")
 
         config = {
-            "factor_cols": ["unit", "party_preference"],
+            "facet_dims": ["unit", "party_preference"],
             "internal_facet": True,
             "plot": "geoplot",
             "plot_args": {"separate_axes": True},
@@ -566,7 +566,7 @@ class TestPlots:
         """Test facet distribution plot."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "facet_dist",
             "internal_facet": True,
@@ -576,7 +576,7 @@ class TestPlots:
     def test_max_diff(self, recompute):
         """Test max_diff plot."""
         config = {
-            "factor_cols": ["question"],
+            "facet_dims": ["question"],
             "filter": {},
             "internal_facet": True,
             "plot": "maxdiff",
@@ -595,7 +595,7 @@ class TestPlots:
         ldf, full_meta = read_parquet_with_metadata(str(self.data_file), lazy=True)
         assert full_meta is not None and full_meta.data is not None
         config = {
-            "factor_cols": ["question"],
+            "facet_dims": ["question"],
             "filter": {},
             "internal_facet": True,
             "plot": "maxdiff",
@@ -613,7 +613,7 @@ class TestPlots:
         """Test ordered population plot."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "ordered_population",
             "internal_facet": True,
@@ -625,7 +625,7 @@ class TestPlots:
         """Sampled ordered population emits real filtered sample rows, not 200 slice summaries."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {"party_preference": ["EKRE", "SDE"]},
             "plot": "ordered_population_sampled",
             "internal_facet": True,
@@ -651,7 +651,7 @@ class TestPlots:
         """The sampled plot must cap filtered raw rows before group observations are melted."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {"party_preference": ["EKRE", "SDE"]},
             "plot": "ordered_population_sampled",
             "internal_facet": True,
@@ -665,7 +665,7 @@ class TestPlots:
         """The implicit sampled plot cap should stay small enough for interactive charts."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "ordered_population_sampled",
             "internal_facet": True,
@@ -678,7 +678,7 @@ class TestPlots:
         """Test Marimekko plot."""
         config = {
             "res_col": "trust",
-            "factor_cols": ["question", "party_preference"],
+            "facet_dims": ["question", "party_preference"],
             "filter": {},
             "plot": "marimekko",
             "internal_facet": True,
@@ -737,7 +737,7 @@ class TestPlots:
         """Test boxplots with result conversion."""
         config = {
             "res_col": "age_group",
-            "factor_cols": ["gender"],
+            "facet_dims": ["gender"],
             "filter": {},
             "plot": "boxplots",
             "internal_facet": True,
@@ -750,7 +750,7 @@ class TestPlots:
         """Test HDI lines with numerical values and custom formatting."""
         config = {
             "res_col": "valitsus",
-            "factor_cols": ["party_preference", "age_group"],
+            "facet_dims": ["party_preference", "age_group"],
             # Isamaa HDI has multiple close options so excluding it
             "filter": {"party_preference": ["Keskerakond", "Reformierakond", "SDE", "EKRE"]},
             "convert_res": "continuous",
@@ -766,7 +766,7 @@ class TestPlots:
         """Test Likert bars with metadata."""
         config = {
             "res_col": "trust",
-            "factor_cols": ["gender", "age_group"],
+            "facet_dims": ["gender", "age_group"],
             "filter": {},
             "plot": "likert_bars",
             "internal_facet": True,
@@ -781,7 +781,7 @@ class TestPlots:
         """Test that appropriate error is raised for missing data file."""
         config = {
             "res_col": "party_preference",
-            "factor_cols": ["age_group"],
+            "facet_dims": ["age_group"],
             "filter": {},
             "plot": "boxplots",
             "internal_facet": True,
@@ -799,7 +799,7 @@ class TestPlots:
         """Test behavior with invalid column names."""
         config = {
             "res_col": "nonexistent_column",
-            "factor_cols": ["age_group"],
+            "facet_dims": ["age_group"],
             "filter": {},
             "plot": "boxplots",
             "internal_facet": True,

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -339,7 +339,7 @@ def test_plot_descriptor_accepts_legacy_factor_cols_key():
 
 
 def test_pp_transform_data_reports_total_and_filtered_weight() -> None:
-    """`total_n` is the pre-filter weight, `filtered_size` the post-filter weight -
+    """`total_size` is the pre-filter weight, `filtered_size` the post-filter weight -
     both weight-summed (not row counts), so consumers can show "filtered to X%"."""
     from salk_toolkit.pp import pp_transform_data
 
@@ -374,11 +374,11 @@ def test_pp_transform_data_reports_total_and_filtered_weight() -> None:
     pi = pp_transform_data(df, data_meta, ppd)
 
     # Weight-based, not row-count-based (which would be 5 and 3)
-    assert pi.total_n == 12.0
+    assert pi.total_size == 12.0
     assert pi.filtered_size == 6.0
 
     # A meta-supplied population total overrides the recomputed weight sum
     data_meta.total_size = 1000.0
     pi = pp_transform_data(df, data_meta, ppd)
-    assert pi.total_n == 1000.0
+    assert pi.total_size == 1000.0
     assert pi.filtered_size == 6.0  # post-filter weight is unaffected

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -15,7 +15,7 @@ from salk_toolkit.pp import (
     _calculate_priority as calculate_priority,
     _transform_cont,
     get_plot_fn,
-    impute_factor_cols,
+    impute_facet_dims,
     matching_plots,
     PlotMeta,
     registry,
@@ -72,7 +72,7 @@ def test_update_data_meta_with_pp_desc_adds_res_meta_and_updates_columns() -> No
     pp_desc_dict = {
         "plot": "test_plot",
         "res_col": "likert_score",
-        "factor_cols": ["gender"],
+        "facet_dims": ["gender"],
         "res_meta": {
             "name": "likert_question",
             "scale": {"col_prefix": "likert_"},
@@ -184,7 +184,7 @@ def test_matching_plots_respects_hidden_flag(registry_guard: Any) -> None:
     data_meta = _make_basic_meta()
     pp_desc = {
         "res_col": "res",
-        "factor_cols": ["facet"],
+        "facet_dims": ["facet"],
         "plot": "visible_plot",
     }
 
@@ -201,8 +201,8 @@ def test_matching_plots_respects_hidden_flag(registry_guard: Any) -> None:
     stk_deregister("hidden_plot")
 
 
-def test_impute_factor_cols_handles_categorical_and_continuous_cases() -> None:
-    """`impute_factor_cols` should handle categorical and continuous conversions."""
+def test_impute_facet_dims_handles_categorical_and_continuous_cases() -> None:
+    """`impute_facet_dims` should handle categorical and continuous conversions."""
     col_meta = {
         "res_group": GroupOrColumnMeta.model_validate({"columns": ["res_variant"], "categories": ["Yes", "No"]}),
         "res_variant": GroupOrColumnMeta.model_validate({"categories": ["Yes", "No"]}),
@@ -213,18 +213,18 @@ def test_impute_factor_cols_handles_categorical_and_continuous_cases() -> None:
     categorical_desc = {
         "plot": "test_plot",
         "res_col": "res_group",
-        "factor_cols": ["region"],
+        "facet_dims": ["region"],
     }
-    categorical_factors = impute_factor_cols(categorical_desc, col_meta)
+    categorical_factors = impute_facet_dims(categorical_desc, col_meta)
     assert categorical_factors == ["res_group", "region", "question"]
 
     continuous_desc = {
         "plot": "test_plot",
         "res_col": "res_group",
-        "factor_cols": ["region"],
+        "facet_dims": ["region"],
         "convert_res": "continuous",
     }
-    continuous_factors = impute_factor_cols(continuous_desc, col_meta)
+    continuous_factors = impute_facet_dims(continuous_desc, col_meta)
     assert continuous_factors == ["question", "region"]
 
 
@@ -325,3 +325,14 @@ def test_get_plot_fn_legacy_wrapper_builds_chart() -> None:
     )
 
     assert hasattr(plot, "to_dict")
+
+
+def test_plot_descriptor_accepts_legacy_factor_cols_key():
+    """Stored descriptors (dashboards, URLs) use the legacy "factor_cols" key."""
+    from salk_toolkit.pp import impute_factor_cols, impute_facet_dims
+    from salk_toolkit.validation import PlotDescriptor
+
+    d = PlotDescriptor.model_validate({"plot": "columns", "res_col": "x", "factor_cols": ["age"]})
+    assert d.facet_dims == ["age"]
+    assert "facet_dims" in d.model_dump()
+    assert impute_factor_cols is impute_facet_dims

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -336,3 +336,49 @@ def test_plot_descriptor_accepts_legacy_factor_cols_key():
     assert d.facet_dims == ["age"]
     assert "facet_dims" in d.model_dump()
     assert impute_factor_cols is impute_facet_dims
+
+
+def test_pp_transform_data_reports_total_and_filtered_weight() -> None:
+    """`total_n` is the pre-filter weight, `filtered_size` the post-filter weight -
+    both weight-summed (not row counts), so consumers can show "filtered to X%"."""
+    from salk_toolkit.pp import pp_transform_data
+
+    data_meta = make_data_meta(
+        {
+            "weight_col": "w",
+            "structure": [
+                {
+                    "name": "demographics",
+                    "scale": {"col_prefix": ""},
+                    "columns": [
+                        ["gender", {"categories": ["Female", "Male"]}],
+                        ["party", {"categories": ["X", "Y"]}],
+                    ],
+                }
+            ],
+        }
+    )
+    # 3 Female @ w=2 (=6) + 2 Male @ w=3 (=6) -> total weight 12, 5 rows
+    df = pd.DataFrame(
+        {
+            "gender": ["Female", "Female", "Female", "Male", "Male"],
+            "party": ["X", "Y", "X", "Y", "X"],
+            "w": [2.0, 2.0, 2.0, 3.0, 3.0],
+        }
+    )
+    ppd = soft_validate(
+        {"plot": "columns", "res_col": "party", "facet_dims": [], "filter": {"gender": ["Female"]}},
+        PlotDescriptor,
+    )
+
+    pi = pp_transform_data(df, data_meta, ppd)
+
+    # Weight-based, not row-count-based (which would be 5 and 3)
+    assert pi.total_n == 12.0
+    assert pi.filtered_size == 6.0
+
+    # A meta-supplied population total overrides the recomputed weight sum
+    data_meta.total_size = 1000.0
+    pi = pp_transform_data(df, data_meta, ppd)
+    assert pi.total_n == 1000.0
+    assert pi.filtered_size == 6.0  # post-filter weight is unaffected


### PR DESCRIPTION
One consolidated PR (subsumes #58 and #61) for the next plots-API vendor+deploy batch — everything the dms Vega-retirement flip needs from salk_toolkit (`dms docs/plans/2026-07-16-vega-retirement-flip-plan.md`, Phase A):

**Additive PlotPayload v1 fields**
- `facet_dims` — the resolved facet dimensions, post-imputation, in descriptor vocabulary and order. `outer_factors` is the *rendered* view of `facet_dims[n_inner:]`: identical for ≤1 outer facet with no translation (the plots-API case today), otherwise translated, reversed (≥2), and merged into one joined key (>2) — pinned by `test_two_outer_facets_reverse_outer_factors`. Ends the frontend's re-derivation of sortable dimensions (the dms#43/#44 bug class).
- `n_inner` — how many of those the plot consumes as inner facets (disambiguates maxdiff's internal-facet variant).
- `cells[][].scale` — each cell's own colour scale `{stops, domain}` (faceted geo's per-cell domains/ramps). Top-level `scale` unchanged.

**Colors contract** (was #58)
- Uncolored facets carry `colors: None` instead of an invented default-palette cycle — the renderer owns the fallback scheme, so payload and spec renders agree. Explicit meta colors (parties, likert ramps) unchanged. dms already handles both wire shapes (its stamp-detection shim deletes once this deploys).

**Facet vocabulary, request side** (was #61)
- `PlotDescriptor.facet_dims` — legacy `"factor_cols"` accepted via validation alias (stored dashboards / deployed frontends keep validating); `model_dump()` emits `facet_dims`.
- `impute_facet_dims` (+ module-level `impute_factor_cols` alias for external callers), `_inner_outer_facets`, stk_explorer keys, locals, tests swept. "Factor" now only means latent factor models.
- Deliberately untouched: `PlotInput.outer_factors` + the payload wire key `outer_factors` (deployed dms contract — and NOT droppable in favour of `facet_dims[n_inner:]`: cell `keys` are zipped against the rendered order, and the ≥2-outer merged/reversed names aren't derivable from `facet_dims`), and `@stk_plot(factor_columns=…)` meta.

Tests: 272 passed (env-sensitive `test_facet_dist` KDE flake deselected — fails identically on origin/main); ruff + pyright clean. Companion: dms-plots-api#4 (lockstep, same deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
