### PR TITLE
Stable row_id index + id-keyed exclusions

### DIFF
--- a/.agents/skills/stk-data-annotations/SKILL.md
+++ b/.agents/skills/stk-data-annotations/SKILL.md
@@ -27,6 +27,7 @@ If you think you need to edit the raw file, you're wrong — use translate/trans
 
 **Definition of done:**
 - [ ] Matches census in category names and granularity — ask for census file if not provided
+- [ ] `id_col` set to a stable respondent-id column if the data has one (see Identifying the id column)
 - [ ] All relevant columns annotated (demographics, opinions, scales, etc.)
 - [ ] Ordered categories correctly ordered (likerts always go negative → positive pole, e.g. disagree → agree); nonordered elements marked; `num_values` set for all ordered columns (centered on zero for likerts, 1–N otherwise, `null` for nonordered entries)
 - [ ] All conventions followed (see below)
@@ -115,6 +116,7 @@ df = read_and_process_data({
   "constants": { "party_colors": { "PartyA": "#ff0000" } },
   "files": [{ "file": "data.sav", "opts": {}, "code": "F0" }],
   "read_opts": {},
+  "id_col": "respondent_id",
   "preprocessing": "df = df[df['age'] >= 18]",
   "postprocessing": null,
   "weight_col": null,
@@ -392,6 +394,17 @@ df, meta = pyreadstat.read_sav("data.sav", apply_value_formats=True)
 ```
 
 For SAV files, `meta.column_labels` often contains the question text in the original language — feed these to a translation function for initial labels.
+
+## Identifying the id column
+
+Every row STK returns is stamped with a stable id and the returned DataFrame is indexed by it. By default that id is the within-file row position (`F0::0`, `F0::1`, …), which is only stable while the source file's bytes don't change. If the survey has a genuine respondent identifier, set **`id_col`** so ids become `{file_code}::{respondent_id}` — stable across re-exports and row reorders, and the correct anchor for `excluded`.
+
+- **Scan for a candidate** while inspecting the raw data: look for columns named like `id`, `respondent_id`, `resp_id`, `caseid`, `ResponseId`, `uuid`, `interview_id`, or a running record number. Verify it: `df['id'].is_unique and df['id'].notna().all()`.
+- **Set it** at the `DataMeta` level (`"id_col": "respondent_id"`), or per-file on a `FileDesc` (`{"file": "...", "code": "W1", "id_col": "resp_id"}`) when different waves name it differently. The per-file value overrides the meta-level default.
+- **Confirm with the user** before committing to a column — picking the wrong one silently misattributes exclusions. If no unique non-null column exists, leave `id_col` unset (positional ids are fine); note the absence in a `comment`.
+- STK hard-errors if the declared `id_col` is missing, has nulls, or is non-unique within a file — so a failing load tells you the candidate was wrong.
+
+`excluded` is keyed on these ids: each entry is `["{row_id}", "reason"]` (e.g. `["F0::102", "careless battery"]` with `id_col`, or `["F0::5", "..."]` positionally). The legacy positional-integer form (`[5, "..."]`) is rejected. Exclusions compose across nested metas — an outer meta references an inner row by its full prefixed id (`M::F0::102`) and is unaffected by what the inner meta itself filters.
 
 ## Validation Commands
 

--- a/salk_toolkit/io/core.py
+++ b/salk_toolkit/io/core.py
@@ -28,6 +28,54 @@ def _str_from_list(val: list[str] | object) -> str:
 ProcessedDataReturn: TypeAlias = tuple[pd.DataFrame, DataMeta | None]
 
 
+# --------------------------------------------------------
+#          STABLE ROW IDENTITY
+# --------------------------------------------------------
+#
+# Every row carries a stable string id in the reserved ``ROW_ID`` column, assigned at load
+# time (before any concat/filter can move rows) and joined across nesting levels as a
+# ``{file_code}::...::{leaf}`` path. It becomes the frame index at every io return boundary,
+# giving callers a unique, deterministic, provenance-bearing index. Ids are opaque: code only
+# prepends prefixes and does exact-string matching, never splits them.
+
+ROW_ID = "row_id"
+
+
+def mint_positional_row_id(df: pd.DataFrame, file_code: str = "F0") -> pd.DataFrame:
+    """Assign a fresh positional ``{file_code}::{i}`` row id in place (leaf files, inline data)."""
+    df[ROW_ID] = [f"{file_code}::{i}" for i in range(len(df))]
+    return df
+
+
+def assert_row_id_intact(df: pd.DataFrame, context: str) -> None:
+    """Fail loudly if user code dropped, nulled, or duplicated the stable row id.
+
+    Filtering/reordering rows is fine; rows added without an id (null) or id collisions are not.
+    """
+    if ROW_ID not in df.columns:
+        raise ValueError(f"{context} removed the '{ROW_ID}' column - stable row ids must be preserved")
+    col = df[ROW_ID]
+    if col.isna().any():
+        raise ValueError(f"{context} produced null row ids - were rows added programmatically without ids?")
+    if col.duplicated().any():
+        dups = list(col[col.duplicated()].unique()[:5])
+        raise ValueError(f"{context} produced duplicate row ids, e.g. {dups} - were rows added programmatically?")
+
+
+def finalize_row_index(df: pd.DataFrame) -> pd.DataFrame:
+    """Set ``ROW_ID`` as the frame index at an io return boundary, asserting uniqueness.
+
+    Idempotent (returns unchanged if already row_id-indexed). Frames with no id at all
+    (legacy parquet, inline data) get a fresh positional one.
+    """
+    if df.index.name == ROW_ID:
+        return df
+    if ROW_ID not in df.columns:
+        mint_positional_row_id(df)
+    assert_row_id_intact(df, "finalize")
+    return df.set_index(ROW_ID)
+
+
 def _convert_number_series_to_categorical(s: pd.Series) -> pd.Series:
     """Convert number series to categorical, avoiding long and unwieldy fractions like 24.666666666667.
 

--- a/salk_toolkit/io/core.py
+++ b/salk_toolkit/io/core.py
@@ -40,10 +40,13 @@ ProcessedDataReturn: TypeAlias = tuple[pd.DataFrame, DataMeta | None]
 
 ROW_ID = "row_id"
 
+# Per-file provenance columns injected into every row (paired, must stay 1-to-1).
+PROVENANCE_COLUMNS = ("file_code", "file_name")
+
 
 def mint_positional_row_id(df: pd.DataFrame, file_code: str = "F0") -> pd.DataFrame:
     """Assign a fresh positional ``{file_code}::{i}`` row id in place (leaf files, inline data)."""
-    df[ROW_ID] = [f"{file_code}::{i}" for i in range(len(df))]
+    df[ROW_ID] = file_code + "::" + pd.RangeIndex(len(df)).astype(str)
     return df
 
 

--- a/salk_toolkit/io/datasets.py
+++ b/salk_toolkit/io/datasets.py
@@ -352,20 +352,13 @@ def _data_with_inferred_meta(data_file: str, **kwargs: object) -> tuple[pd.DataF
 def _repair_merge_row_ids(mdf: pd.DataFrame, tag: str) -> None:
     """Restore ROW_ID uniqueness after a horizontal merge, in place (corner case).
 
-    A merge keeps the left row's id, but ``right``/``outer`` joins introduce right-only rows
-    with no left id, and one-to-many / ``cross`` joins duplicate an id across the fanned-out
-    rows. Right-only rows get a fresh ``{tag}::{position}`` id; duplicated ids get a ``::m{k}``
-    per-group suffix. Both are deterministic since merge output order is deterministic.
+    Left ids are kept where already unique (many-to-one enrich). Right-only rows (NaN id, from
+    ``right``/``outer`` joins) collapse to ``tag`` and any id duplicated by a one-to-many/``cross``
+    join gets a deterministic ``::m{k}`` suffix - merge output order is deterministic.
     """
-    rid = mdf[ROW_ID]
-    na_mask = rid.isna()
-    if na_mask.any():
-        mdf.loc[na_mask, ROW_ID] = f"{tag}::" + pd.RangeIndex(int(na_mask.sum())).astype(str)
-        rid = mdf[ROW_ID]
-    dup_mask = rid.duplicated(keep=False)
-    if dup_mask.any():
-        cc = mdf.loc[dup_mask].groupby(ROW_ID).cumcount()
-        mdf.loc[dup_mask, ROW_ID] = rid[dup_mask].astype(str) + "::m" + cc.astype(str)
+    rid = mdf[ROW_ID].fillna(tag)
+    dup = rid.duplicated(keep=False)
+    mdf[ROW_ID] = rid.mask(dup, rid + "::m" + rid.groupby(rid).cumcount().astype(str))
 
 
 def _perform_merges(

--- a/salk_toolkit/io/datasets.py
+++ b/salk_toolkit/io/datasets.py
@@ -26,7 +26,14 @@ from salk_toolkit.validation import (
     soft_validate,
 )
 
-from salk_toolkit.io.core import ProcessedDataReturn, _str_from_list
+from salk_toolkit.io.core import (
+    ROW_ID,
+    ProcessedDataReturn,
+    _str_from_list,
+    assert_row_id_intact,
+    finalize_row_index,
+    mint_positional_row_id,
+)
 from salk_toolkit.io.meta import _fix_meta_categories, _is_categorical, fix_df_with_meta
 from salk_toolkit.io.parquet import read_parquet_with_metadata
 from salk_toolkit.io.pipeline import _process_annotated_data
@@ -85,6 +92,9 @@ def read_annotated_data(
 
     if meta_obj is not None or not infer:
         assert isinstance(data, pd.DataFrame), "Expected data to be DataFrame"
+        # Idempotent for the json/yaml path (already row_id-indexed); mints positional ids for a
+        # legacy parquet written before stable ids existed.
+        data = finalize_row_index(data)
         if return_meta:
             return (data, meta_obj)
         return data
@@ -333,6 +343,25 @@ def _data_with_inferred_meta(data_file: str, **kwargs: object) -> tuple[pd.DataF
     return df, meta_result
 
 
+def _repair_merge_row_ids(mdf: pd.DataFrame, tag: str) -> None:
+    """Restore ROW_ID uniqueness after a horizontal merge, in place (corner case).
+
+    A merge keeps the left row's id, but ``right``/``outer`` joins introduce right-only rows
+    with no left id, and one-to-many / ``cross`` joins duplicate an id across the fanned-out
+    rows. Right-only rows get a fresh ``{tag}::{position}`` id; duplicated ids get a ``::m{k}``
+    per-group suffix. Both are deterministic since merge output order is deterministic.
+    """
+    rid = mdf[ROW_ID]
+    if rid.isna().any():
+        na_mask = rid.isna()
+        mdf.loc[na_mask, ROW_ID] = [f"{tag}::{i}" for i in range(int(na_mask.sum()))]
+        rid = mdf[ROW_ID]
+    if rid.duplicated().any():
+        dup_mask = rid.duplicated(keep=False)
+        cc = mdf.groupby(ROW_ID).cumcount()
+        mdf.loc[dup_mask, ROW_ID] = rid[dup_mask].astype(str) + "::m" + cc[dup_mask].astype(str)
+
+
 def _perform_merges(
     df: pd.DataFrame,
     merges: SingleMergeSpec | list[SingleMergeSpec],
@@ -355,14 +384,14 @@ def _perform_merges(
     if not isinstance(merges, list):
         merges = [merges]
 
-    for ms in merges:
+    for merge_idx, ms in enumerate(merges):
         # ms is always a SingleMergeSpec Pydantic model
         file = ms.file
         on = ms.on if isinstance(ms.on, list) else [ms.on]
         add = ms.add
         how = ms.how
 
-        ndf = read_and_process_data(file, constants=constants)
+        ndf = read_and_process_data(file, constants=constants).reset_index()  # lift row_id out of the index
         if add:
             ms_on = on
             ms_add = list(add) if isinstance(add, list) else [add]
@@ -370,7 +399,7 @@ def _perform_merges(
         # Drop system provenance columns from the merge-side to avoid suffix collisions.
         # Keep them on the left df (the main dataset) only.
         ndf = ndf.drop(
-            columns=[c for c in ["file_code", "file_name"] if c in ndf.columns and c not in on],
+            columns=[c for c in ["file_code", "file_name", ROW_ID] if c in ndf.columns and c not in on],
             errors="ignore",
         )
         overlap = (set(df.columns) & set(ndf.columns)) - set(on)
@@ -384,6 +413,8 @@ def _perform_merges(
         if data_meta is not None:
             ndf = fix_df_with_meta(ndf, data_meta)
         mdf = pd.merge(df, ndf, on=on, how=how)
+        if ROW_ID in mdf.columns:
+            _repair_merge_row_ids(mdf, f"merge{merge_idx}")
 
         for c in on:
             mdf[c] = mdf[c].astype(df[c].dtype)
@@ -452,6 +483,7 @@ def read_and_process_data(
     # Check if desc_obj is DataDescription with inline data
     if isinstance(desc_obj, DataDescription) and desc_obj.data is not None:
         df, meta_obj, einfo = pd.DataFrame(data=desc_obj.data), None, {}
+        mint_positional_row_id(df)  # inline data has no source-file ids
     else:
         # Extract parameters from kwargs
         ignore_exclusions = kwargs.get("ignore_exclusions", False)
@@ -495,6 +527,7 @@ def read_and_process_data(
         globs = {"pd": pd, "np": np, "sp": sp, "stk": stk, "df": df, **einfo, **constants}
         if desc_obj.preprocessing:
             exec(_str_from_list(desc_obj.preprocessing), globs)
+            assert_row_id_intact(globs["df"], "DataDescription preprocessing")
 
         if desc_obj.filter:
             globs["df"] = globs["df"][eval(desc_obj.filter, globs)]
@@ -507,7 +540,11 @@ def read_and_process_data(
                 globs["df"].loc[:, newcols] = fix_df_with_meta(globs["df"][newcols], kwargs["data_meta"])
         if desc_obj.postprocessing and not skip_postprocessing:
             exec(_str_from_list(desc_obj.postprocessing), globs)
+            assert_row_id_intact(globs["df"], "DataDescription postprocessing")
         df = globs["df"]
+
+    # Stable, unique, deterministic index at the return boundary.
+    df = finalize_row_index(df)
 
     if return_meta:
         assert meta_obj is not None, "Meta should not be None when return_meta=True"

--- a/salk_toolkit/io/datasets.py
+++ b/salk_toolkit/io/datasets.py
@@ -27,6 +27,7 @@ from salk_toolkit.validation import (
 )
 
 from salk_toolkit.io.core import (
+    PROVENANCE_COLUMNS,
     ROW_ID,
     ProcessedDataReturn,
     _str_from_list,
@@ -107,8 +108,10 @@ def read_annotated_data(
     add_original_inds = bool(kwargs.get("add_original_inds", False))
     # Use conditional to match overloads based on return_meta value
     # Pass return_meta first (after *) to help Pyright match overloads
+    # finalize_row_index keeps this path's return shape consistent with the annotated branch
+    # above (the return_raw path in _process_annotated_data does not index by row_id on its own).
     if return_meta:
-        return _process_annotated_data(
+        idata, imeta = _process_annotated_data(
             data_file=fname,
             meta=inferred_meta,
             return_meta=True,
@@ -117,15 +120,18 @@ def read_annotated_data(
             only_fix_categories=only_fix_categories,
             add_original_inds=add_original_inds,
         )
+        return (finalize_row_index(idata), imeta)
     else:
-        return _process_annotated_data(
-            data_file=fname,
-            meta=inferred_meta,
-            return_meta=False,
-            return_raw=return_raw,
-            ignore_exclusions=ignore_exclusions,
-            only_fix_categories=only_fix_categories,
-            add_original_inds=add_original_inds,
+        return finalize_row_index(
+            _process_annotated_data(
+                data_file=fname,
+                meta=inferred_meta,
+                return_meta=False,
+                return_raw=return_raw,
+                ignore_exclusions=ignore_exclusions,
+                only_fix_categories=only_fix_categories,
+                add_original_inds=add_original_inds,
+            )
         )
 
 
@@ -352,14 +358,14 @@ def _repair_merge_row_ids(mdf: pd.DataFrame, tag: str) -> None:
     per-group suffix. Both are deterministic since merge output order is deterministic.
     """
     rid = mdf[ROW_ID]
-    if rid.isna().any():
-        na_mask = rid.isna()
-        mdf.loc[na_mask, ROW_ID] = [f"{tag}::{i}" for i in range(int(na_mask.sum()))]
+    na_mask = rid.isna()
+    if na_mask.any():
+        mdf.loc[na_mask, ROW_ID] = f"{tag}::" + pd.RangeIndex(int(na_mask.sum())).astype(str)
         rid = mdf[ROW_ID]
-    if rid.duplicated().any():
-        dup_mask = rid.duplicated(keep=False)
-        cc = mdf.groupby(ROW_ID).cumcount()
-        mdf.loc[dup_mask, ROW_ID] = rid[dup_mask].astype(str) + "::m" + cc[dup_mask].astype(str)
+    dup_mask = rid.duplicated(keep=False)
+    if dup_mask.any():
+        cc = mdf.loc[dup_mask].groupby(ROW_ID).cumcount()
+        mdf.loc[dup_mask, ROW_ID] = rid[dup_mask].astype(str) + "::m" + cc.astype(str)
 
 
 def _perform_merges(
@@ -399,7 +405,7 @@ def _perform_merges(
         # Drop system provenance columns from the merge-side to avoid suffix collisions.
         # Keep them on the left df (the main dataset) only.
         ndf = ndf.drop(
-            columns=[c for c in ["file_code", "file_name", ROW_ID] if c in ndf.columns and c not in on],
+            columns=[c for c in [*PROVENANCE_COLUMNS, ROW_ID] if c in ndf.columns and c not in on],
             errors="ignore",
         )
         overlap = (set(df.columns) & set(ndf.columns)) - set(on)

--- a/salk_toolkit/io/pipeline.py
+++ b/salk_toolkit/io/pipeline.py
@@ -23,6 +23,7 @@ from salk_toolkit.validation import (
 
 from salk_toolkit.io import readers
 from salk_toolkit.io.core import (
+    PROVENANCE_COLUMNS,
     ROW_ID,
     ProcessedDataReturn,
     _deterministic_categories_and_values,
@@ -40,7 +41,7 @@ from salk_toolkit.io.sources import _load_data_files
 def _file_meta_map(dfs: dict[str, pd.DataFrame]) -> dict[str, str]:
     """Return mapping of file_code -> file_name, requiring a 1-to-1 relationship."""
     fm = (
-        pd.concat((df[["file_code", "file_name"]] for df in dfs.values()), ignore_index=True)
+        pd.concat((df[list(PROVENANCE_COLUMNS)] for df in dfs.values()), ignore_index=True)
         .assign(file_code=lambda d: d.file_code.astype(str), file_name=lambda d: d.file_name.astype(str))
         .drop_duplicates()
     )
@@ -136,13 +137,15 @@ def _process_annotated_data(
             warn("Processing main meta file")  # Print this to separate warnings for input jsons from main
     elif isinstance(raw_data, dict):
         # Directly-injected frames may lack ids: mint a positional one per file_code.
+        # copy(deep=False) so we add the column without mutating the caller's frame.
         raw_data_dict = {
-            fc: (df if ROW_ID in df.columns else mint_positional_row_id(df.copy(), fc)) for fc, df in raw_data.items()
+            fc: (df if ROW_ID in df.columns else mint_positional_row_id(df.copy(deep=False), fc))
+            for fc, df in raw_data.items()
         }
         einfo = {}
     else:
         # Backward compatibility: single DataFrame -> treat as single-file dict
-        single = raw_data if ROW_ID in raw_data.columns else mint_positional_row_id(raw_data.copy(), "F0")
+        single = raw_data if ROW_ID in raw_data.columns else mint_positional_row_id(raw_data.copy(deep=False), "F0")
         raw_data_dict = {"F0": single}
         einfo = {}
 
@@ -518,11 +521,12 @@ def _process_annotated_data(
     # by an inner meta simply matches nothing here).
     if meta_obj.excluded and not ignore_exclusions:
         excl_ids = [rid for rid, _ in meta_obj.excluded]
-        present = set(ndf_df[ROW_ID])
-        missing = [rid for rid in excl_ids if rid not in present]
+        mask = ndf_df[ROW_ID].isin(excl_ids)
+        matched = set(ndf_df[ROW_ID][mask])
+        missing = [rid for rid in excl_ids if rid not in matched]
         if missing:
             warn(f"{len(missing)} excluded row_id(s) not present in data (already filtered upstream?): {missing[:5]}")
-        ndf_df = ndf_df[~ndf_df[ROW_ID].isin(excl_ids)]
+        ndf_df = ndf_df[~mask]
 
     if not add_original_inds:
         ndf_df.drop(columns=["original_inds"], inplace=True)

--- a/salk_toolkit/io/pipeline.py
+++ b/salk_toolkit/io/pipeline.py
@@ -23,10 +23,14 @@ from salk_toolkit.validation import (
 
 from salk_toolkit.io import readers
 from salk_toolkit.io.core import (
+    ROW_ID,
     ProcessedDataReturn,
     _deterministic_categories_and_values,
     _is_series_of_lists,
     _str_from_list,
+    assert_row_id_intact,
+    finalize_row_index,
+    mint_positional_row_id,
 )
 from salk_toolkit.io.create_blocks import _create_new_columns_and_metas
 from salk_toolkit.io.meta import _fix_meta_categories
@@ -126,15 +130,20 @@ def _process_annotated_data(
             ignore_exclusions=ignore_exclusions,
             only_fix_categories=only_fix_categories,
             add_original_inds=add_original_inds,
+            id_col=meta_obj.id_col,
         )
         if inp_meta is not None:
             warn("Processing main meta file")  # Print this to separate warnings for input jsons from main
     elif isinstance(raw_data, dict):
-        raw_data_dict = raw_data
+        # Directly-injected frames may lack ids: mint a positional one per file_code.
+        raw_data_dict = {
+            fc: (df if ROW_ID in df.columns else mint_positional_row_id(df.copy(), fc)) for fc, df in raw_data.items()
+        }
         einfo = {}
     else:
         # Backward compatibility: single DataFrame -> treat as single-file dict
-        raw_data_dict = {"F0": raw_data}
+        single = raw_data if ROW_ID in raw_data.columns else mint_positional_row_id(raw_data.copy(), "F0")
+        raw_data_dict = {"F0": single}
         einfo = {}
 
     if return_raw:
@@ -167,6 +176,7 @@ def _process_annotated_data(
             }
             exec(_str_from_list(meta_obj.preprocessing), globs)
             raw_data_dict[file_code] = globs["df"]
+            assert_row_id_intact(raw_data_dict[file_code], f"preprocessing of {file_code}")
 
     # Ensure file metadata columns always survive end-to-end (also if preprocessing dropped/mutated them).
     file_names_in_order: list[str] = []
@@ -469,6 +479,14 @@ def _process_annotated_data(
         # Add processed group to structure
         new_structure[group.name] = group
 
+    # Carry the stable row id through: it is a system column (not part of the meta structure)
+    # so it is not rebuilt column-by-column. ndf_df is positionally aligned with raw_data_concat
+    # here (same rows, same order), so copy it over by position.
+    if not raw_data_concat.empty:
+        if len(ndf_df) != len(raw_data_concat):
+            raise ValueError("row count changed during column processing - cannot align stable row ids")
+        ndf_df[ROW_ID] = raw_data_concat[ROW_ID].to_numpy()
+
     if meta_obj.postprocessing is not None and not only_fix_categories:
         globs = {
             "pd": pd,
@@ -481,6 +499,7 @@ def _process_annotated_data(
         }
         exec(_str_from_list(meta_obj.postprocessing), globs)
         ndf_df = globs["df"]
+        assert_row_id_intact(ndf_df, "postprocessing")
 
     # Update meta with new structure (including any groups created during processing)
     meta_obj = meta_obj.model_copy(update={"structure": new_structure})
@@ -492,12 +511,24 @@ def _process_annotated_data(
     if not isinstance(meta_obj, DataMeta):
         meta_obj = soft_validate(meta_obj, DataMeta)
 
+    # Positional counter over the processed frame - kept only on request; no longer drives exclusions.
     ndf_df["original_inds"] = np.arange(len(ndf_df))
+
+    # Apply meta exclusions by stable row id (composes across nesting - an id already filtered
+    # by an inner meta simply matches nothing here).
     if meta_obj.excluded and not ignore_exclusions:
-        excl_inds = [i for i, _ in meta_obj.excluded]
-        ndf_df = ndf_df[~ndf_df["original_inds"].isin(excl_inds)]
+        excl_ids = [rid for rid, _ in meta_obj.excluded]
+        present = set(ndf_df[ROW_ID])
+        missing = [rid for rid in excl_ids if rid not in present]
+        if missing:
+            warn(f"{len(missing)} excluded row_id(s) not present in data (already filtered upstream?): {missing[:5]}")
+        ndf_df = ndf_df[~ndf_df[ROW_ID].isin(excl_ids)]
+
     if not add_original_inds:
         ndf_df.drop(columns=["original_inds"], inplace=True)
+
+    # Stable, unique, deterministic index at the return boundary.
+    ndf_df = finalize_row_index(ndf_df)
 
     # Return with meta as dict if requested (for backward compatibility)
     if return_meta:

--- a/salk_toolkit/io/sources.py
+++ b/salk_toolkit/io/sources.py
@@ -19,7 +19,7 @@ from salk_toolkit.validation import (
 )
 
 from salk_toolkit.io import readers
-from salk_toolkit.io.core import ROW_ID, _deterministic_categories_and_values
+from salk_toolkit.io.core import ROW_ID, _deterministic_categories_and_values, mint_positional_row_id
 from salk_toolkit.io.meta import _fix_meta_categories
 
 
@@ -102,19 +102,19 @@ def _reconcile_categories(
     return reconciled
 
 
-def _assign_row_id(df: pd.DataFrame, file_code: str, id_col: str | None, data_file: str) -> None:
+def _assign_row_id(df: pd.DataFrame, file_code: str, id_col: str | None, data_file: str, inherited: bool) -> None:
     """Assign or extend the stable ``ROW_ID`` column in place.
 
-    Nested/annotated sources already carry a row id (as a column after the caller lifts it
-    from the index) - we only prepend this level's ``file_code``. Raw leaf files get a fresh
-    ``{file_code}::{leaf}`` id, where ``leaf`` is the declared ``id_col`` value (validated
-    unique + non-null) or the 0-based within-file position.
+    ``inherited`` means this frame came from a nested annotated/parquet source and already
+    carries a row id (lifted from its index by the caller) - we only prepend this level's
+    ``file_code``. Otherwise it is a raw leaf file and gets a fresh ``{file_code}::{leaf}``
+    id, where ``leaf`` is the declared ``id_col`` value (validated unique + non-null) or the
+    0-based within-file position. A stray ``row_id`` *column* in a raw file is a reserved-name
+    collision and is overwritten, mirroring how ``file_code``/``file_name`` are handled.
     """
-    prefix = f"{file_code}::"
-    if ROW_ID in df.columns:  # nested annotated source: extend the existing path
-        df[ROW_ID] = prefix + df[ROW_ID].astype(str)
-        return
-    if id_col is not None:  # natural key: survives row reorders / re-exports of the source
+    if inherited:  # nested annotated source: extend the existing path
+        df[ROW_ID] = f"{file_code}::" + df[ROW_ID].astype(str)
+    elif id_col is not None:  # natural key: survives row reorders / re-exports of the source
         if id_col not in df.columns:
             raise ValueError(f"id_col '{id_col}' not found in {data_file}")
         col = df[id_col]
@@ -122,9 +122,9 @@ def _assign_row_id(df: pd.DataFrame, file_code: str, id_col: str | None, data_fi
             raise ValueError(f"id_col '{id_col}' has null values in {data_file}")
         if col.duplicated().any():
             raise ValueError(f"id_col '{id_col}' is not unique within {data_file}")
-        df[ROW_ID] = prefix + col.astype(str)
+        df[ROW_ID] = f"{file_code}::" + col.astype(str)
     else:  # fall back to within-file position (deterministic for a byte-stable source)
-        df[ROW_ID] = [f"{prefix}{i}" for i in range(len(df))]
+        mint_positional_row_id(df, file_code)
 
 
 def _load_data_files(
@@ -216,7 +216,10 @@ def _load_data_files(
         # A nested/annotated source (or a parquet with embedded ids) comes back indexed by
         # ROW_ID; lift it to a column so it survives the internal reset_index(drop=True) churn
         # (re-indexed at the outer boundary) and so _assign_row_id can extend the path below.
-        if raw_data.index.name == ROW_ID:
+        # Only such a lifted id counts as inherited - a raw file's own `row_id` column is a
+        # reserved-name collision, not an id to build on.
+        inherited_row_id = raw_data.index.name == ROW_ID
+        if inherited_row_id:
             raw_data = raw_data.reset_index()
 
         # If data is multi-indexed, flatten the index
@@ -253,7 +256,7 @@ def _load_data_files(
             raw_data[k] = pd.Categorical([v] * len(raw_data), categories=cats)
 
         # Stamp the stable row id (per-file id_col overrides the meta-level default).
-        _assign_row_id(raw_data, file_code, fd.id_col or id_col, cast(str, data_file))
+        _assign_row_id(raw_data, file_code, fd.id_col or id_col, cast(str, data_file), inherited_row_id)
 
         raw_data_dict[file_code] = raw_data
 

--- a/salk_toolkit/io/sources.py
+++ b/salk_toolkit/io/sources.py
@@ -19,7 +19,7 @@ from salk_toolkit.validation import (
 )
 
 from salk_toolkit.io import readers
-from salk_toolkit.io.core import _deterministic_categories_and_values
+from salk_toolkit.io.core import ROW_ID, _deterministic_categories_and_values
 from salk_toolkit.io.meta import _fix_meta_categories
 
 
@@ -102,6 +102,31 @@ def _reconcile_categories(
     return reconciled
 
 
+def _assign_row_id(df: pd.DataFrame, file_code: str, id_col: str | None, data_file: str) -> None:
+    """Assign or extend the stable ``ROW_ID`` column in place.
+
+    Nested/annotated sources already carry a row id (as a column after the caller lifts it
+    from the index) - we only prepend this level's ``file_code``. Raw leaf files get a fresh
+    ``{file_code}::{leaf}`` id, where ``leaf`` is the declared ``id_col`` value (validated
+    unique + non-null) or the 0-based within-file position.
+    """
+    prefix = f"{file_code}::"
+    if ROW_ID in df.columns:  # nested annotated source: extend the existing path
+        df[ROW_ID] = prefix + df[ROW_ID].astype(str)
+        return
+    if id_col is not None:  # natural key: survives row reorders / re-exports of the source
+        if id_col not in df.columns:
+            raise ValueError(f"id_col '{id_col}' not found in {data_file}")
+        col = df[id_col]
+        if col.isna().any():
+            raise ValueError(f"id_col '{id_col}' has null values in {data_file}")
+        if col.duplicated().any():
+            raise ValueError(f"id_col '{id_col}' is not unique within {data_file}")
+        df[ROW_ID] = prefix + col.astype(str)
+    else:  # fall back to within-file position (deterministic for a byte-stable source)
+        df[ROW_ID] = [f"{prefix}{i}" for i in range(len(df))]
+
+
 def _load_data_files(
     data_files: list[FileDesc],
     path: str | None,
@@ -109,6 +134,7 @@ def _load_data_files(
     ignore_exclusions: bool = False,
     only_fix_categories: bool = False,
     add_original_inds: bool = False,
+    id_col: str | None = None,
 ) -> tuple[dict[str, pd.DataFrame], DataMeta | None, dict[str, object]]:
     """Internal helper to load files defined in metadata or descriptions.
 
@@ -187,6 +213,12 @@ def _load_data_files(
 
         readers.stk_loaded_files_set.add(mapped_file)
 
+        # A nested/annotated source (or a parquet with embedded ids) comes back indexed by
+        # ROW_ID; lift it to a column so it survives the internal reset_index(drop=True) churn
+        # (re-indexed at the outer boundary) and so _assign_row_id can extend the path below.
+        if raw_data.index.name == ROW_ID:
+            raw_data = raw_data.reset_index()
+
         # If data is multi-indexed, flatten the index
         if isinstance(raw_data.columns, pd.MultiIndex):
             raw_data.columns = [" | ".join(tpl) for tpl in raw_data.columns]
@@ -219,6 +251,9 @@ def _load_data_files(
                 continue
             cats = extra_field_categories[k]
             raw_data[k] = pd.Categorical([v] * len(raw_data), categories=cats)
+
+        # Stamp the stable row id (per-file id_col overrides the meta-level default).
+        _assign_row_id(raw_data, file_code, fd.id_col or id_col, cast(str, data_file))
 
         raw_data_dict[file_code] = raw_data
 

--- a/salk_toolkit/pp.py
+++ b/salk_toolkit/pp.py
@@ -270,6 +270,7 @@ class PlotMeta(PBase):
 
 special_columns: List[str] = [
     "id",
+    "row_id",
     "weight",
     "draw",
     "original_inds",

--- a/salk_toolkit/validation.py
+++ b/salk_toolkit/validation.py
@@ -74,6 +74,7 @@ from pydantic import (
     ValidationError,
 )
 from pydantic_extra_types.color import Color
+import numpy as np
 
 from salk_toolkit.utils import JSONValue, replace_constants
 
@@ -335,12 +336,14 @@ class FileDesc(BaseModel):
     id_col: Optional[str] = None  # Column in this file that uniquely identifies rows - overrides DataMeta.id_col
 
     @model_serializer(mode="wrap")
-    def _serialize(self, handler: Callable[[BaseModel], dict[str, Any]]) -> dict[str, Any]:
-        """Drop ``id_col`` from output when unset, to keep serialized metas free of ``id_col: null`` noise."""
-        d = handler(self)
-        if d.get("id_col") is None:
-            d.pop("id_col", None)
-        return d
+    def _serialize(self, handler: Callable[[BaseModel], dict[str, Any]], info: SerializationInfo) -> dict[str, Any]:
+        """Strip None/default fields (``id_col``, ``code``, empty ``opts``) via the shared serializer.
+
+        Extra ``extra="allow"`` fields (e.g. wave labels) are not model fields, so they survive.
+        """
+        from salk_toolkit.serialization import serialize_pbase
+
+        return serialize_pbase(self, handler, info)
 
 
 def _normalize_data_desc_input(meta: Any, read_opts_key: str = "read_opts") -> Any:  # noqa: ANN401
@@ -441,7 +444,9 @@ class DataMeta(PBase):
         """
         if isinstance(v, list):
             for entry in v:
-                if isinstance(entry, (list, tuple)) and entry and isinstance(entry[0], int):
+                # bool is an int subclass but never a valid position; np.integer is not an int subclass.
+                first = entry[0] if isinstance(entry, (list, tuple)) and entry else None
+                if isinstance(first, (int, np.integer)) and not isinstance(first, bool):
                     raise ValueError(
                         f"excluded entry {entry!r} uses a positional integer row index. "
                         "Exclusions are now keyed on the stable string row_id (e.g. 'F0::42' "

--- a/salk_toolkit/validation.py
+++ b/salk_toolkit/validation.py
@@ -67,6 +67,7 @@ from pydantic import (
     Field,
     SerializationInfo,
     ValidationInfo,
+    field_validator,
     model_validator,
     model_serializer,
     BeforeValidator,
@@ -331,6 +332,15 @@ class FileDesc(BaseModel):
     file: str
     opts: Dict = DF(dict)
     code: Optional[str] = None  # Short code identifier for the file (e.g., 'F1', 'F2' or 'wave1', 'wave2')
+    id_col: Optional[str] = None  # Column in this file that uniquely identifies rows - overrides DataMeta.id_col
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler: Callable[[BaseModel], dict[str, Any]]) -> dict[str, Any]:
+        """Drop ``id_col`` from output when unset, to keep serialized metas free of ``id_col: null`` noise."""
+        d = handler(self)
+        if d.get("id_col") is None:
+            d.pop("id_col", None)
+        return d
 
 
 def _normalize_data_desc_input(meta: Any, read_opts_key: str = "read_opts") -> Any:  # noqa: ANN401
@@ -413,11 +423,32 @@ class DataMeta(PBase):
     postprocessing: Optional[Union[str, List[str]]] = None  # Performed after columns and blocks have been processed
 
     weight_col: Optional[str] = None  # Column to use for weighting - overriden by model to population weight column
+    id_col: Optional[str] = None  # Raw column uniquely identifying rows within each file (e.g. respondent id)
 
-    # List of data points that should be excluded in alyses
-    excluded: List[Tuple[int, str]] = []  # Index of row + str  reason for exclusion
+    # List of data points that should be excluded in analyses
+    excluded: List[Tuple[str, str]] = []  # (row_id, reason) - row_id is the stable string id, not a position
     total_size: Optional[float] = None  # Optional total population size override
     draws_data: Dict[str, Tuple[str, int]] = DF(dict)  # Precomputed draws info keyed by column
+
+    @field_validator("excluded", mode="before")
+    @classmethod
+    def _reject_positional_excluded(cls, v: Any) -> Any:  # noqa: ANN401  # pydantic validators require Any
+        """Fail loudly on the legacy positional-int exclusion format.
+
+        ``excluded`` is now ``(row_id, reason)`` keyed on the stable string row id, not an
+        absolute position into the concatenated frame. Legacy ``[[int, reason], ...]`` metas
+        must be migrated - see specs/stable-row-index-design.md.
+        """
+        if isinstance(v, list):
+            for entry in v:
+                if isinstance(entry, (list, tuple)) and entry and isinstance(entry[0], int):
+                    raise ValueError(
+                        f"excluded entry {entry!r} uses a positional integer row index. "
+                        "Exclusions are now keyed on the stable string row_id (e.g. 'F0::42' "
+                        "or 'F0::<respondent_id>'). Migrate the meta to the new format - see "
+                        "specs/stable-row-index-design.md."
+                    )
+        return v
 
     @model_validator(mode="before")
     @classmethod

--- a/specs/stable-row-index-design.md
+++ b/specs/stable-row-index-design.md
@@ -1,0 +1,107 @@
+# Stable row index and id-keyed exclusions
+
+**Modules:** `salk_toolkit/validation.py`, `salk_toolkit/io/` (`sources.py`, `pipeline.py`, `datasets.py`, `parquet.py`), `.cursor/skills/stk-data-annotations/`
+
+## Goal
+
+Every DataFrame returned by the io layer carries a unique, deterministic index that names
+each row's provenance, and meta exclusions are keyed on that identity. Today row identity
+is a RangeIndex rebuilt by `reset_index(drop=True)` at every concat, and `excluded` entries
+are absolute integer positions into the post-concat frame — so any inner filter, file
+reorder, or preprocessing row change silently shifts what an outer meta's exclusions point
+at. With identity assigned at load time, meta-within-meta exclusions compose to arbitrary
+depth: each level filters by id, and a change in an inner filter can never re-aim an outer
+one.
+
+## Design
+
+**Row id.** Each row gets a string id in a reserved system column `row_id` (joining
+`file_code`/`file_name`), assigned in `_load_data_files` immediately after each file is
+read — before any concat, preprocessing, or column processing can move rows:
+
+- Raw file (csv/sav/xlsx/…): `{file_code}::{leaf}` where `leaf` is the value of the
+  declared `id_col` if set, else the 0-based row position within that file.
+- Annotated inner dataset (json/yaml/parquet loaded as a `files` entry): rows already
+  carry ids; the outer level prepends its own code — `wave1::37` stacked under code `F0`
+  becomes `F0::wave1::37`. Variable nesting depth is why this is a delimited string, not a
+  MultiIndex.
+- Ids are opaque: nothing ever splits them, code only prepends prefixes and does exact
+  string matching, so `::` inside id_col values is harmless.
+
+The id rides as a column through the positionally-indexed middle of the pipeline (the
+`file_index_ranges`/`.iloc` machinery is untouched). At the return boundary of
+`read_annotated_data` / `read_and_process_data` it becomes the index
+(`set_index("row_id")`), asserted unique and non-null.
+
+**`id_col` meta syntax.** `DataMeta.id_col` names a raw-data column that uniquely
+identifies rows within each file (a respondent id); `FileDesc.id_col` overrides it
+per-file. Validated at load: the column must exist, be non-null, and unique within the
+file — hard error otherwise. Positional leaf ids are deterministic only for a byte-stable
+source file; a declared natural key survives re-exports and reorders, so the annotation
+skill actively looks for one.
+
+**Exclusions.** `DataMeta.excluded` becomes `List[Tuple[str, str]]` — `(row_id, reason)` —
+applied at the same pipeline point as today via `~df["row_id"].isin(ids)`. An exclusion id
+that matches nothing emits a `warn` (naming the unmatched ids) but is not an error: an
+inner meta may legitimately have already filtered that row, so no-match must not break the
+load — but a typo'd id is otherwise undetectable, so it is surfaced. Legacy integer entries
+fail validation with a message pointing here —
+no positional fallback is kept (the few metas in the wild that used ints are migrated by
+hand as encountered; the exclusion-writing tools in SIP are being rebuilt against the new
+syntax on data-quality-v2).
+
+**Parquet round-trip.** `write_parquet_with_metadata` already preserves the index via
+`pa.Table.from_pandas`. On read, if the restored frame carries a `row_id` index (or
+column), it is lifted back into the `row_id` column before the stacking concat would
+destroy it; frames without one (raw parquet sources) get fresh positional ids like any
+other raw file. At the outer return boundary the column is set back as the index as usual.
+
+**Merges.** `_perform_merges` runs after exclusions, so ids never need to be referenced
+post-merge — only the output invariant matters. Repair after each merge, cheapest
+deterministic form: right-only rows (NaN id from `right`/`outer` joins) get
+`{merge_file_code}::{position}`; duplicated ids (one-to-many, `cross`) get a
+`::m{cumcount}` suffix. Deterministic because merge output order is deterministic.
+
+**Row-count discipline.** After each user-code hook (`preprocessing`, `postprocessing`,
+`subgroup_transform` on the frame level), assert `row_id` still exists, non-null, unique.
+Dropping or reordering rows is fine; rows *added* by user code have no identity and fail
+loudly. No auto-minting of ids for synthesized rows until a real use case demands it.
+
+**Scope of the guarantee.** io-layer returns only. The pp layer bootstrap
+(`_augment_draws`) duplicates rows by design and redraws/resets its own index; there the
+id is provenance ("which source row generated this draw"), not a unique key.
+
+**`original_inds` unchanged.** `add_original_inds=True` keeps producing the positional
+post-processing `np.arange` column; it no longer plays any role in exclusions. SIP's runner
+is unaffected: it already resets `sdf`'s index right after load
+(`reset_index(names="orig_index")`), so the string `row_id` index is captured as
+`orig_index` provenance and replaced with a clean RangeIndex for SIP's positional work.
+
+**Annotation skill.** `stk-data-annotations` gains an id-column step: when annotating,
+scan the raw data for candidate respondent-id columns (names like `id`, `resp_id`,
+`caseid`, `ResponseId`, `uuid`; verify `is_unique` and non-null), confirm the choice with
+the user, and set `id_col` in the meta. Added to the definition-of-done checklist and the
+JSON quick reference.
+
+## Implementation notes
+
+- `FileDesc` has `extra="allow"` and extra fields are injected into the data as constant
+  categorical columns (`sources.py` extra-field loop) — `id_col` must be a *declared*
+  field so it stays out of `__pydantic_extra__`.
+- The nested lift must happen before `pd.concat(...).reset_index(drop=True)` in the
+  stacking path — that concat is what currently destroys inner identity.
+- `combine_first` in the create-block path aligns on index labels and currently works by
+  RangeIndex luck; with `row_id` as a column it keeps working unchanged, but do not set
+  the index earlier than the return boundary or the positional `.iloc` slicing breaks.
+- The `raw_data` direct-injection paths (`raw_data=` DataFrame or dict in
+  `_process_annotated_data`) mint positional ids at ingestion, same rule as raw files.
+- Leaf positional ids are within-file, so adding/removing/reordering *files* never shifts
+  another file's ids; row edits inside one raw file shift only that file's tail — the
+  residual fragility `id_col` exists to remove.
+- `read_and_process_data("path.json")` wraps the bare path in a synthetic `F0` FileDesc, so
+  its returned ids gain a redundant `F0::` prefix (`F0::M::F0::37`). Harmless and still
+  unique/deterministic; the canonical nested loader `read_annotated_data` yields the clean
+  `M::F0::37`. Exclusions are always authored and applied at the `read_annotated_data`
+  level (clean ids), so the wrapper prefix never affects exclusion keys.
+- `FileDesc` omits `id_col` from serialization when `None`, keeping saved metas free of
+  `id_col: null` noise (mirrors how the col-meta serializer drops defaults).

--- a/specs/stable-row-index-design.md
+++ b/specs/stable-row-index-design.md
@@ -57,10 +57,11 @@ destroy it; frames without one (raw parquet sources) get fresh positional ids li
 other raw file. At the outer return boundary the column is set back as the index as usual.
 
 **Merges.** `_perform_merges` runs after exclusions, so ids never need to be referenced
-post-merge — only the output invariant matters. Repair after each merge, cheapest
-deterministic form: right-only rows (NaN id from `right`/`outer` joins) get
-`{merge_file_code}::{position}`; duplicated ids (one-to-many, `cross`) get a
-`::m{cumcount}` suffix. Deterministic because merge output order is deterministic.
+post-merge — only the output invariant matters. `_repair_merge_row_ids` keeps left ids where
+already unique (many-to-one enrich); right-only rows (NaN id from `right`/`outer` joins)
+collapse to the merge `tag` and any id duplicated by a one-to-many/`cross` join gets a
+`::m{k}` per-group suffix — one `fillna` + `duplicated` + `groupby().cumcount()` pass,
+deterministic because merge output order is.
 
 **Row-count discipline.** After each user-code hook (`preprocessing`, `postprocessing`,
 `subgroup_transform` on the frame level), assert `row_id` still exists, non-null, unique.

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1851,6 +1851,17 @@ class TestAdvancedFeatures:
         with pytest.raises(ValueError, match="not unique"):
             read_annotated_data(str(meta_file))
 
+    def test_raw_row_id_column_is_not_adopted_as_identity(self, csv_file, meta_file):
+        """A raw file's own 'row_id' column is a reserved-name collision, overwritten not inherited."""
+        pd.DataFrame({"row_id": ["x", "y", "z"], "resp": [7, 8, 9], "value": [1, 2, 3]}).to_csv_file(csv_file)
+        write_json(
+            meta_file,
+            {"file": "test.csv", "id_col": "resp", "structure": [{"name": "t", "columns": ["resp", "value"]}]},
+        )
+        # id_col wins; the stray user row_id column must not become identity.
+        df = read_annotated_data(str(meta_file))
+        assert list(df.index) == ["F0::7", "F0::8", "F0::9"]
+
     def test_nested_exclusions_compose(self, temp_dir):
         """Outer exclusions key on the stable id and are unaffected by inner filter changes."""
         (temp_dir / "w.csv").write_text("resp,val\n101,10\n102,20\n103,30\n104,40\n")
@@ -3385,10 +3396,11 @@ class TestMultiSourceColumns:
         data_df, data_meta = read_and_process_data(str(meta_file), return_meta=True)
 
         dumped = data_meta.model_dump(mode="json")
+        # FileDesc serialization strips default/None fields (empty opts, unset id_col) via serialize_pbase.
         assert dumped["files"] == [
-            {"file": "file1.csv", "opts": {}, "code": "F0"},
-            {"file": "file2.csv", "opts": {}, "code": "F1"},
-            {"file": "file3.csv", "opts": {}, "code": "F2"},
+            {"file": "file1.csv", "code": "F0"},
+            {"file": "file2.csv", "code": "F1"},
+            {"file": "file3.csv", "code": "F2"},
         ]
         # Core structure entries should match (additional system blocks may also be present)
         assert {"name": "demographics_topk", "columns": ["topk_R1", "topk_R2"]} in dumped["structure"]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2125,6 +2125,22 @@ class TestReadAndProcessData:
         with pytest.raises(ValueError, match="suffix"):
             read_and_process_data(desc)
 
+    def test_merge_fanout_keeps_unique_row_id(self, temp_dir):
+        """A one-to-many merge keeps left ids where unique and suffixes the fanned-out duplicates."""
+        main_csv = temp_dir / "main.csv"
+        merge_csv = temp_dir / "merge.csv"
+        # main row 'A' matches two merge rows -> fan-out; 'B' matches one.
+        pd.DataFrame({"municipality": ["A", "B"], "val": [1, 2]}).to_csv_file(main_csv)
+        pd.DataFrame({"municipality": ["A", "A", "B"], "extra": ["p", "q", "r"]}).to_csv_file(merge_csv)
+
+        df = read_and_process_data({"file": str(main_csv), "merge": {"file": str(merge_csv), "on": "municipality"}})
+
+        assert len(df) == 3
+        assert df.index.name == "row_id"
+        assert df.index.is_unique
+        # The fanned-out left row (F0::0) is suffixed; the singleton (F0::1) keeps its id.
+        assert sorted(df.index) == ["F0::0::m0", "F0::0::m1", "F0::1"]
+
     def test_merge_applies_categorical_conversion_from_metadata(self, temp_dir):
         """Merged columns should be converted to categorical based on metadata definitions."""
         main_csv = temp_dir / "main.csv"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -332,7 +332,8 @@ class TestReadAnnotatedData:
         data_df, data_meta = read_and_process_data(str(meta_file), return_meta=True)
 
         newcols = data_df.columns.difference(df.columns).difference(["file_code", "file_name"])
-        diffs = data_df[newcols].replace("<NA>", pd.NA)
+        # data_df is now indexed by the stable row_id; drop it to compare values against a RangeIndex.
+        diffs = data_df[newcols].replace("<NA>", pd.NA).reset_index(drop=True)
         expected_result = pd.DataFrame(
             [
                 ["USA", "USA", "Canada", "Mexico"],
@@ -572,7 +573,7 @@ class TestReadAnnotatedData:
         expected_df["file_code"] = "F0"
         expected_df["file_name"] = "test_meta.json"
         expected_df = expected_df[sorted(expected_df.columns)]
-        assert_frame_equal(data_df, expected_df, check_dtype=False, check_categorical=False)
+        assert_frame_equal(data_df.reset_index(drop=True), expected_df, check_dtype=False, check_categorical=False)
 
         # Compare structures
         self._assert_structure_matches(
@@ -691,7 +692,7 @@ class TestReadAnnotatedData:
             expected_df = expected_df[data_df.columns]
 
             assert_frame_equal(
-                data_df,
+                data_df.reset_index(drop=True),
                 expected_df,
                 check_dtype=False,
                 check_categorical=False,
@@ -1750,16 +1751,17 @@ class TestAdvancedFeatures:
         assert df["final"].tolist() == [101, 102, 103, 104, 105]
 
     def test_exclusions_handling(self, csv_file, meta_file):
-        """Test exclusions handling"""
+        """Exclusions are keyed by the stable row_id, here derived from a declared id_col."""
         pd.DataFrame({"value": [1, 2, 3, 4, 5], "id": [1, 2, 3, 4, 5]}).to_csv_file(csv_file)
 
         meta = {
             "file": "test.csv",
+            "id_col": "id",  # row_id becomes F0::<id>
             "structure": [{"name": "test", "columns": ["id", "value"]}],
             "excluded": [
-                [1, "test exclusion"],
-                [3, "another exclusion"],
-            ],  # Exclude rows 1 and 3
+                ["F0::1", "test exclusion"],
+                ["F0::3", "another exclusion"],
+            ],  # Exclude the rows whose id is 1 and 3
         }
         write_json(meta_file, meta)
 
@@ -1767,9 +1769,40 @@ class TestAdvancedFeatures:
 
         # Should have 3 rows (original 5 minus 2 excluded)
         assert len(df) == 3
+        assert df.index.name == "row_id"
+        assert df.index.is_unique
         # Should not contain excluded rows
-        assert 1 not in df.index.tolist()
-        assert 3 not in df.index.tolist()
+        assert "F0::1" not in df.index.tolist()
+        assert "F0::3" not in df.index.tolist()
+
+    def test_exclusions_unmatched_id_warns(self, csv_file, meta_file):
+        """An exclusion id that matches no row warns (typo guard) but does not fail the load."""
+        pd.DataFrame({"value": [1, 2, 3]}).to_csv_file(csv_file)
+
+        meta = {
+            "file": "test.csv",
+            "structure": [{"name": "test", "columns": ["value"]}],
+            "excluded": [["F0::0", "real"], ["F0::nonexistent", "typo"]],
+        }
+        write_json(meta_file, meta)
+
+        with pytest.warns(UserWarning, match="not present in data"):
+            df = read_annotated_data(str(meta_file))
+        assert len(df) == 2  # only the real match is dropped
+
+    def test_exclusions_reject_positional_int(self, csv_file, meta_file):
+        """Legacy positional-int exclusions are rejected with a migration message."""
+        pd.DataFrame({"value": [1, 2, 3, 4, 5]}).to_csv_file(csv_file)
+
+        meta = {
+            "file": "test.csv",
+            "structure": [{"name": "test", "columns": ["value"]}],
+            "excluded": [[1, "legacy positional"]],
+        }
+        write_json(meta_file, meta)
+
+        with pytest.raises(Exception, match="positional integer"):
+            read_annotated_data(str(meta_file))
 
     def test_ignore_exclusions_parameter(self, csv_file, meta_file):
         """Test ignore_exclusions parameter"""
@@ -1778,7 +1811,7 @@ class TestAdvancedFeatures:
         meta = {
             "file": "test.csv",
             "structure": [{"name": "test", "columns": ["value"]}],
-            "excluded": [[1, "test exclusion"], [3, "another exclusion"]],
+            "excluded": [["F0::1", "test exclusion"], ["F0::3", "another exclusion"]],
         }
         write_json(meta_file, meta)
 
@@ -1786,6 +1819,92 @@ class TestAdvancedFeatures:
 
         # Should have all 5 rows when ignoring exclusions
         assert len(df) == 5
+
+    def test_row_id_index_positional(self, csv_file, meta_file):
+        """Without id_col, the index is a deterministic within-file positional row_id."""
+        pd.DataFrame({"value": [10, 20, 30]}).to_csv_file(csv_file)
+        write_json(meta_file, {"file": "test.csv", "structure": [{"name": "t", "columns": ["value"]}]})
+
+        df = read_annotated_data(str(meta_file))
+        assert df.index.name == "row_id"
+        assert list(df.index) == ["F0::0", "F0::1", "F0::2"]
+        assert df.index.is_unique
+
+    def test_row_id_index_natural_key(self, csv_file, meta_file):
+        """A declared id_col produces {file_code}::{id} row ids that survive row reordering."""
+        pd.DataFrame({"resp": [101, 102, 103], "value": [10, 20, 30]}).to_csv_file(csv_file)
+        write_json(
+            meta_file,
+            {"file": "test.csv", "id_col": "resp", "structure": [{"name": "t", "columns": ["resp", "value"]}]},
+        )
+
+        df = read_annotated_data(str(meta_file))
+        assert list(df.index) == ["F0::101", "F0::102", "F0::103"]
+
+    def test_row_id_natural_key_must_be_unique(self, csv_file, meta_file):
+        """A non-unique id_col is a hard error."""
+        pd.DataFrame({"resp": [1, 1, 2], "value": [10, 20, 30]}).to_csv_file(csv_file)
+        write_json(
+            meta_file,
+            {"file": "test.csv", "id_col": "resp", "structure": [{"name": "t", "columns": ["resp", "value"]}]},
+        )
+        with pytest.raises(ValueError, match="not unique"):
+            read_annotated_data(str(meta_file))
+
+    def test_nested_exclusions_compose(self, temp_dir):
+        """Outer exclusions key on the stable id and are unaffected by inner filter changes."""
+        (temp_dir / "w.csv").write_text("resp,val\n101,10\n102,20\n103,30\n104,40\n")
+        inner = temp_dir / "inner_meta.json"
+        write_json(
+            inner,
+            {
+                "file": "w.csv",
+                "id_col": "resp",
+                "structure": [{"name": "g", "columns": ["resp", "val"]}],
+                "excluded": [["F0::102", "inner drops 102"]],
+            },
+        )
+        outer = temp_dir / "outer_meta.json"
+        write_json(
+            outer,
+            {
+                "files": [{"file": "inner_meta.json", "code": "M"}],
+                "structure": [{"name": "g", "columns": ["resp", "val"]}],
+                "excluded": [["M::F0::101", "outer drops 101"]],
+            },
+        )
+
+        # inner drops 102, outer drops 101 -> 103, 104 remain, with the full nested path id.
+        df = read_annotated_data(str(outer))
+        assert list(df.index) == ["M::F0::103", "M::F0::104"]
+
+        # Toggle the inner filter to also drop 103; the outer reference to 101 still resolves.
+        write_json(
+            inner,
+            {
+                "file": "w.csv",
+                "id_col": "resp",
+                "structure": [{"name": "g", "columns": ["resp", "val"]}],
+                "excluded": [["F0::102", "x"], ["F0::103", "now dropped too"]],
+            },
+        )
+        df2 = read_annotated_data(str(outer))
+        assert list(df2.index) == ["M::F0::104"]
+
+    def test_row_id_survives_parquet_roundtrip(self, csv_file, meta_file, temp_dir):
+        """Writing a processed frame to parquet and reading it back preserves the row_id index."""
+        pd.DataFrame({"resp": [101, 102, 103], "value": [10, 20, 30]}).to_csv_file(csv_file)
+        write_json(
+            meta_file,
+            {"file": "test.csv", "id_col": "resp", "structure": [{"name": "t", "columns": ["resp", "value"]}]},
+        )
+        df, meta = read_annotated_data(str(meta_file), return_meta=True)
+
+        pq = temp_dir / "processed.parquet"
+        write_parquet_with_metadata(df, {"data": meta}, str(pq))
+        df2 = read_annotated_data(str(pq))
+        assert df2.index.name == "row_id"
+        assert list(df2.index) == list(df.index)
 
     def test_column_prefixing(self, csv_file, meta_file):
         """Test column prefixing"""
@@ -3300,7 +3419,7 @@ class TestMultiSourceColumns:
         ]
         edf = pd.DataFrame(expected_data, columns=["file_code", "id", "topk_1", "topk_2", "topk_R1", "topk_R2"])
         # data_df may contain additional system columns (file_ind, file_name) in multi-file mode
-        assert_frame_equal(data_df[edf.columns], edf, check_dtype=False, check_categorical=False)
+        assert_frame_equal(data_df[edf.columns].reset_index(drop=True), edf, check_dtype=False, check_categorical=False)
         assert {"file_name"}.issubset(data_df.columns)
 
 


### PR DESCRIPTION
## Goal

Guarantee that **every DataFrame the io layer returns has a unique, deterministic, provenance-bearing index**, and make meta exclusions robust at any nesting depth.

Today row identity is a default `RangeIndex` rebuilt by `reset_index(drop=True)` at every concat/merge, and `excluded` entries are absolute integer positions into the post-concat frame — so any inner filter, file reorder, or preprocessing row change silently shifts what an outer meta's exclusions point at.

## Design

- **Load-time identity.** Each row is stamped with a reserved `row_id` column in `_load_data_files`, *before* any concat/filter/preprocessing can move rows. `row_id = {file_code}::{leaf}`, where `leaf` is a declared `id_col` value or the within-file position. Nesting prepends each level's code (`M::F0::37`). Ids are opaque paths — only prefixed / exact-matched, never split. It rides as a column through the positional pipeline middle and becomes the frame **index** at every return boundary (`finalize_row_index`), asserted unique + non-null.
- **`id_col` meta syntax.** New `DataMeta.id_col` + per-file `FileDesc.id_col` override — a natural respondent key that survives re-exports/reorders. Validated: must exist, be non-null and unique within the file (hard error otherwise). Falls back to positional ids when unset.
- **Exclusions re-keyed.** `excluded` is now `(row_id, reason)`. Legacy positional-int form is rejected with a migration message. An unmatched exclusion id **warns** (typo guard) but doesn't fail — so exclusions compose across nested metas: an outer meta references an inner row by its full prefixed id and is unaffected by what the inner meta itself filters.
- **Corner cases.** Merge repair for right/outer-only rows (`{tag}::{pos}`) and one-to-many/cross duplicates (`::m{k}`); parquet round-trips the id via the preserved index; inline/injected frames mint positional ids; user-code hooks (`preprocessing`/`postprocessing`) fail loudly if rows are added without ids.

Helpers live in `io/core.py`: `ROW_ID`, `mint_positional_row_id`, `assert_row_id_intact`, `finalize_row_index`.

## Compatibility

- **SIP unaffected** — its runner already `reset_index(names="orig_index")`s `sdf` right after load, so the string index flows in cleanly and is captured as `orig_index` provenance. `original_inds` (positional counter) is retained but no longer drives exclusions.
- `read_and_process_data("path.json")` string-shorthand wraps the file in a synthetic `F0` FileDesc, adding a redundant `F0::` prefix; the canonical nested loader `read_annotated_data` yields clean ids, and exclusions are always authored/applied at that level. Documented in the spec.
- Legacy metas using integer `excluded` must migrate (none in code author them; the SIP exclusion tools are being rebuilt against the new syntax on data-quality-v2).

## Skill

`stk-data-annotations` gains an "Identifying the id column" step (candidate scan → verify unique/non-null → confirm with user), a DoD checklist item, and the `id_col` quick-reference entry.

## Tests

9 new io tests (positional + natural-key ids, non-unique id_col error, legacy-int rejection, unmatched-id warning, nested-exclusion composition with inner filter toggled, parquet round-trip). Existing frame-comparison and exclusion tests updated for the new index. **276 pass, 1 skipped; ruff + pyright clean.**

Design spec: `specs/stable-row-index-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)