### PR TITLE
refactor: factor_cols → facet_dims vocabulary (request side)

### DIFF
--- a/salk_toolkit/pp.py
+++ b/salk_toolkit/pp.py
@@ -7,7 +7,7 @@ It maps annotated survey data to Altair charts by:
 - discovering eligible plots via the registry metadata in `salk_toolkit.plots`
 - lazily transforming data with Polars, including filters, melts, draws, and
   aggregation helpers such as `pp_transform_data` / `_wrangle_data`
-- enriching metadata (`update_data_meta_with_pp_desc`, `impute_factor_cols`,
+- enriching metadata (`update_data_meta_with_pp_desc`, `impute_facet_dims`,
   `matching_plots`) so dashboards and CLI tools can reason about aliases,
   ordering, draws, and group scales
 - building final Altair specs with `create_plot`, colour utilities, tooltips,
@@ -636,8 +636,8 @@ def matching_plots(
     pp_desc = soft_validate(pp_desc, PlotDescriptor)
 
     if impute:
-        factor_cols = impute_factor_cols(pp_desc, extract_column_meta(data_meta), get_plot_meta(pp_desc.plot))
-        pp_desc = pp_desc.model_copy(update={"factor_cols": factor_cols})
+        facet_dims = impute_facet_dims(pp_desc, extract_column_meta(data_meta), get_plot_meta(pp_desc.plot))
+        pp_desc = pp_desc.model_copy(update={"facet_dims": facet_dims})
 
     col_meta, _ = _update_data_meta_with_pp_desc(data_meta, pp_desc)
 
@@ -673,9 +673,9 @@ def matching_plots(
         if cat_vals:
             nonneg = min(cat_vals) >= 0
 
-    factor_cols = pp_desc.factor_cols
+    facet_dims = pp_desc.facet_dims
     facet_metas = []
-    for cn in factor_cols:
+    for cn in facet_dims:
         meta = col_meta.get(cn, GroupOrColumnMeta())
         facet_metas.append({"name": cn, **meta.model_dump(mode="python")})
     # Determine if data is categorical
@@ -1064,7 +1064,7 @@ def pp_transform_data(
 
     # Figure out which columns we actually need
     weight_col = data_meta.weight_col or "row_weights"
-    factor_cols = list(pp_desc.factor_cols).copy()
+    facet_dims = list(pp_desc.facet_dims).copy()
 
     # Ensure weight column is present (fill with 1.0 if not)
     if weight_col not in all_col_names:
@@ -1075,11 +1075,11 @@ def pp_transform_data(
 
     # For transforming purposest, res_col is not a factor.
     # It will be made one for categorical plots for plotting part, but for pp_transform_data, remove it
-    if pp_desc.res_col in factor_cols:
-        factor_cols.remove(pp_desc.res_col)
+    if pp_desc.res_col in facet_dims:
+        facet_dims.remove(pp_desc.res_col)
     base_cols = list(columns) if columns is not None else []
     extra_cols = base_cols + ([weight_col] + (["draw"] if plot_meta.draws else []))
-    cols = [pp_desc.res_col] + factor_cols + list(pp_desc.filter.keys() if pp_desc.filter else [])
+    cols = [pp_desc.res_col] + facet_dims + list(pp_desc.filter.keys() if pp_desc.filter else [])
     cols += [c for c in extra_cols if c in all_col_names and c not in cols]
 
     # If any aliases are used, cconvert them to column names according to the data_meta
@@ -1109,7 +1109,7 @@ def pp_transform_data(
         filtered_df = df
 
     # Discretize factor columns that are numeric
-    for c in factor_cols:
+    for c in facet_dims:
         if c in cols and schema[c].is_numeric():
             current_meta = c_meta.get(c)
             filtered_df, labels = _discretize_continuous(filtered_df, c, current_meta)
@@ -1207,7 +1207,7 @@ def pp_transform_data(
     if pp_desc.res_col in gc_dict:
         value_vars = [c for c in gc_dict[pp_desc.res_col] if c in cols]
         n_questions = len(value_vars)  # Only cols that exist in the data
-        id_vars = [c for c in cols if (c not in value_vars or c in factor_cols)]
+        id_vars = [c for c in cols if (c not in value_vars or c in facet_dims)]
         prefix = original_question_meta.col_prefix or ""
         categories = [v.removeprefix(prefix) for v in value_vars]
         question_meta = _question_meta_clone(original_question_meta, categories)
@@ -1255,7 +1255,7 @@ def pp_transform_data(
         filtered_df = filtered_df.with_columns(pl.col("question").cast(pl.Enum(value_vars)))
     else:
         n_questions = 1
-        if "question" in factor_cols:
+        if "question" in facet_dims:
             filtered_df = filtered_df.with_columns(pl.lit(pp_desc.res_col).alias("question").cast(pl.Categorical))
             question_meta = _question_meta_clone(original_question_meta, categories=[pp_desc.res_col])
             if original_question_colors:
@@ -1263,7 +1263,7 @@ def pp_transform_data(
             c_meta["question"] = question_meta
 
     # Aggregate the data into right shape
-    pi = _wrangle_data(filtered_df, c_meta, factor_cols, weight_col, pp_desc, n_questions)
+    pi = _wrangle_data(filtered_df, c_meta, facet_dims, weight_col, pp_desc, n_questions)
 
     pi.val_format = val_format
     pi.val_range = val_range  # Currently not used
@@ -1283,7 +1283,7 @@ def pp_transform_data(
 def _wrangle_data(
     raw_df: pl.LazyFrame,
     col_meta: MutableMapping[str, GroupOrColumnMeta],
-    factor_cols: List[str],
+    facet_dims: List[str],
     weight_col: str,
     pp_desc: PlotDescriptor,
     n_questions: int,
@@ -1299,10 +1299,10 @@ def _wrangle_data(
     draws = plot_meta.draws
     data_format = plot_meta.data_format
 
-    # if pp_desc['res_col'] in factor_cols: factor_cols.remove(pp_desc['res_col']) # Res cannot also be a factor
+    # if pp_desc['res_col'] in facet_dims: facet_dims.remove(pp_desc['res_col']) # Res cannot also be a factor
 
     # Determine the groupby dimensions
-    gb_dims = factor_cols + (["draw"] if draws else []) + (["id"] if plot_meta.data_format == "raw" else [])
+    gb_dims = facet_dims + (["draw"] if draws else []) + (["id"] if plot_meta.data_format == "raw" else [])
 
     # If we have no groupby dimensions, add a dummy one so we don't have to handle the empty case
     if len(gb_dims) == 0:
@@ -1570,39 +1570,39 @@ def _create_tooltip(
     return tooltips, data
 
 
-def _remove_from_internal_fcols(cname: str, factor_cols: List[str], n_inner: int) -> int:
+def _remove_from_internal_fcols(cname: str, facet_dims: List[str], n_inner: int) -> int:
     """Shift ``cname`` out of the inner facet slice while preserving order."""
 
-    if cname not in factor_cols[:n_inner]:
+    if cname not in facet_dims[:n_inner]:
         return n_inner
-    factor_cols.remove(cname)
-    if n_inner > len(factor_cols):
+    facet_dims.remove(cname)
+    if n_inner > len(facet_dims):
         n_inner -= 1
-    factor_cols.insert(n_inner, cname)
+    facet_dims.insert(n_inner, cname)
     return n_inner
 
 
-def _inner_outer_factors(
-    factor_cols: List[str],
+def _inner_outer_facets(
+    facet_dims: List[str],
     pp_desc: PlotDescriptor,
     plot_meta: PlotMeta,
 ) -> tuple[List[str], int]:
-    """Return `(factor_cols, n_inner)` after respecting descriptor overrides."""
+    """Return `(facet_dims, n_inner)` after respecting descriptor overrides."""
 
     # Determine how many factors to use as inner facets
     in_f = pp_desc.internal_facet if pp_desc.internal_facet is not None else False
     res_col = pp_desc.res_col
     n_min_f, n_rec_f = plot_meta.n_facets or (0, 0)
     n_inner: int = (n_rec_f if in_f else n_min_f) if isinstance(in_f, bool) else int(in_f)  # type: ignore[arg-type]
-    if n_inner > len(factor_cols):
-        n_inner = len(factor_cols)
+    if n_inner > len(facet_dims):
+        n_inner = len(facet_dims)
 
     # If question facet as inner facet for a no_question_facet plot, just move it out
     if plot_meta.no_question_facet:
-        n_inner = _remove_from_internal_fcols("question", factor_cols, n_inner)
-        n_inner = _remove_from_internal_fcols(res_col, factor_cols, n_inner)
+        n_inner = _remove_from_internal_fcols("question", facet_dims, n_inner)
+        n_inner = _remove_from_internal_fcols(res_col, facet_dims, n_inner)
 
-    return factor_cols, n_inner
+    return facet_dims, n_inner
 
 
 # --------------------------------------------------------
@@ -1650,8 +1650,8 @@ def create_plot(
     pi.plot_args = plot_args
 
     # Get list of factor columns (adding question and category if needed)
-    factor_cols_input = list(pp_desc.factor_cols or [])
-    factor_cols, n_inner = _inner_outer_factors(factor_cols_input, pp_desc, plot_meta)
+    facet_dims_input = list(pp_desc.facet_dims or [])
+    facet_dims, n_inner = _inner_outer_facets(facet_dims_input, pp_desc, plot_meta)
 
     # Reorder categories if required
     if pp_desc.sort:
@@ -1665,8 +1665,8 @@ def create_plot(
             # This converts the categorical into numeric values and then sorts by the mean of the value
             # If the sort column IS the first facet, the numeric-scale sort is incoherent -
             # fall through to the plain mean-of-value_col sort below.
-            if plot_meta.sort_numeric_first_facet and cn != factor_cols[0]:
-                f0 = factor_cols[0]
+            if plot_meta.sort_numeric_first_facet and cn != facet_dims[0]:
+                f0 = facet_dims[0]
                 nvals = _get_cat_num_vals(col_meta[f0], pp_desc)
                 cats = col_meta[f0].categories or []
                 cmap = dict(zip(cats, nvals))
@@ -1685,20 +1685,20 @@ def create_plot(
             order = ordervals.sort_values(ascending=ascending).index
             data[cn] = pd.Categorical(data[cn], list(order))
     elif "ordering_value" in data.columns and pp_desc.plot == "maxdiff":
-        if pp_desc.factor_cols:
-            q = pp_desc.factor_cols[0]
+        if pp_desc.facet_dims:
+            q = pp_desc.facet_dims[0]
             order = data.groupby(q, observed=True)["ordering_value"].mean().sort_values(ascending=False).index
             data[q] = pd.Categorical(data[q], list(order))
 
     # Stash the resolved facet split for payload consumers (wire: facet_dims/n_inner)
-    pi.facet_dims = list(factor_cols)
+    pi.facet_dims = list(facet_dims)
     pi.n_inner = n_inner
 
     # Handle internal facets (and translate as needed)
     pi.facets = []
 
     if n_inner > 0:
-        for cn in factor_cols[:n_inner]:
+        for cn in facet_dims[:n_inner]:
             base_meta = col_meta.get(cn, GroupOrColumnMeta())
             fd = FacetMeta(
                 col=cn,
@@ -1719,8 +1719,8 @@ def create_plot(
                     if facet_meta:
                         plot_args[k] = _meta_to_plain(facet_meta).get(k)
 
-        factor_cols = factor_cols[n_inner:]  # Leave rest for external faceting
-    pi.outer_factors = factor_cols
+        facet_dims = facet_dims[n_inner:]  # Leave rest for external faceting
+    pi.outer_factors = facet_dims
 
     if plot_meta.no_faceting and len(pi.outer_factors) > 0:
         return_matrix_of_plots = True
@@ -1940,15 +1940,12 @@ def _apply_publish_mode(plot: AltairChart) -> AltairChart:
     return type(plot).from_dict(spec)
 
 
-def impute_factor_cols(
+def impute_facet_dims(
     pp_desc: PlotDescriptor | Dict[str, Any],
     col_meta: Mapping[str, GroupOrColumnMeta],
     plot_meta: PlotMeta | None = None,
 ) -> List[str]:
-    """Compute the full factor_cols list, including question and res_col as needed.
-
-    Ensures descriptor has sensible defaults for `factor_cols`.
-    """
+    """Compute the full facet_dims list, including question and res_col as needed."""
 
     if isinstance(pp_desc, dict) and "plot" not in pp_desc:
         pp_desc["plot"] = "default"
@@ -1956,7 +1953,7 @@ def impute_factor_cols(
     # Ensure pp_desc is a PlotDescriptor object
     pp_desc = soft_validate(pp_desc, PlotDescriptor)
 
-    factor_cols = list(pp_desc.factor_cols or [])
+    facet_dims = list(pp_desc.facet_dims or [])
 
     # Determine if res is categorical
     res_col = pp_desc.res_col
@@ -1967,28 +1964,32 @@ def impute_factor_cols(
     cat_res = has_categories and convert_res != "continuous"
 
     # Add res_col if we are working with a categorical input (and not converting it to continuous)
-    if cat_res and res_col not in factor_cols:
-        factor_cols.insert(0, res_col)
-    if len(factor_cols) < 1 and not has_q:
+    if cat_res and res_col not in facet_dims:
+        facet_dims.insert(0, res_col)
+    if len(facet_dims) < 1 and not has_q:
         # Create 'question' as a dummy dimension so we have at least one factor
         # (generally required for plotting)
         has_q = True
 
     # If we need to, add question as a factor to list
-    if has_q and "question" not in factor_cols:
+    if has_q and "question" not in facet_dims:
         if cat_res:
-            factor_cols.append("question")  # Put it last for categorical values
+            facet_dims.append("question")  # Put it last for categorical values
         else:
-            factor_cols.insert(
+            facet_dims.insert(
                 0, "question"
             )  # And first for continuous values, as it then often represents the "category"
 
-    # Pass the factor_cols through the same changes done inside plot pipeline to make more explicit what happens
+    # Pass the facet_dims through the same changes done inside plot pipeline to make more explicit what happens
     if plot_meta:
-        factor_cols, _ = _inner_outer_factors(factor_cols, pp_desc, plot_meta)
+        facet_dims, _ = _inner_outer_facets(facet_dims, pp_desc, plot_meta)
 
-    return factor_cols
+    return facet_dims
 
+
+
+# Legacy name kept for external callers
+impute_factor_cols = impute_facet_dims
 
 def e2e_plot(
     pp_desc: Dict[str, Any] | PlotDescriptor,
@@ -2028,8 +2029,8 @@ def e2e_plot(
         raise ValueError(f"Parquet file {data_file} has no data metadata")
 
     if impute:
-        factor_cols = impute_factor_cols(pp_desc, extract_column_meta(data_meta), get_plot_meta(pp_desc.plot))
-        pp_desc = pp_desc.model_copy(update={"factor_cols": factor_cols})
+        facet_dims = impute_facet_dims(pp_desc, extract_column_meta(data_meta), get_plot_meta(pp_desc.plot))
+        pp_desc = pp_desc.model_copy(update={"facet_dims": facet_dims})
 
     if check_match:
         matches = matching_plots(pp_desc, full_df, data_meta, details=True, list_hidden=True)

--- a/salk_toolkit/tools/explorer.py
+++ b/salk_toolkit/tools/explorer.py
@@ -132,7 +132,7 @@ with st.spinner("Loading libraries.."):
         cont_transform_options,
         create_plot,
         get_plot_meta,
-        impute_factor_cols,
+        impute_facet_dims,
         matching_plots,
         pp_transform_data,
     )
@@ -351,14 +351,14 @@ with st.sidebar:  # .expander("Select dimensions"):
     modifiers = c_meta[obs_name].modifiers
     all_dims = list(modifiers) + all_dims
 
-    facet_dims = all_dims
+    facetable_dims = all_dims
     if len(input_files) > 1:
-        facet_dims = ["input_file"] + facet_dims
+        facetable_dims = ["input_file"] + facetable_dims
 
-    args["factor_cols"] = facet_ui(facet_dims, two=True)
+    args["facet_dims"] = facet_ui(facetable_dims, two=True)
 
     # Check if any facet dims match observation dim or each other
-    if len(set(args["factor_cols"] + [obs_name])) != len(args["factor_cols"]) + 1:
+    if len(set(args["facet_dims"] + [obs_name])) != len(args["facet_dims"]) + 1:
         st.markdown("""Please choose facets different from observation dimension""")
         st.stop()
 
@@ -366,7 +366,7 @@ with st.sidebar:  # .expander("Select dimensions"):
     sort = st.toggle("Sort facets", False, key="sort")
 
     # Make all dimensions explicit
-    args["factor_cols"] = impute_factor_cols(args, c_meta)
+    args["facet_dims"] = impute_facet_dims(args, c_meta)
 
     # Plot type
     matching = matching_plots(args, first_data, first_data_meta)
@@ -416,7 +416,7 @@ with st.sidebar:  # .expander("Select dimensions"):
             if agg_fn != "mean":
                 args["agg_fn"] = agg_fn
 
-        sortable = args["factor_cols"]
+        sortable = args["facet_dims"]
         if plot_meta_dict.get("sort_numeric_first_facet"):
             sortable = sortable[1:]
         if sort and len(sortable) > 0:
@@ -426,17 +426,17 @@ with st.sidebar:  # .expander("Select dimensions"):
             args["sort"] = {sort_facet: ascending}
 
         qpos = st.selectbox("Question position", ["Auto", 1, 2, 3], key="q_pos")
-        if "question" in args["factor_cols"] and qpos != "Auto":
-            args["factor_cols"] = [c for c in args["factor_cols"] if c != "question"]
-            args["factor_cols"].insert(int(qpos) - 1, "question")
+        if "question" in args["facet_dims"] and qpos != "Auto":
+            args["facet_dims"] = [c for c in args["facet_dims"] if c != "question"]
+            args["facet_dims"].insert(int(qpos) - 1, "question")
 
         # Drop a now-incoherent sort: if the sort target ended up as the first facet
         # and the plot uses sort_numeric_first_facet, the numeric-scale sort is meaningless.
         if (
             plot_meta_dict.get("sort_numeric_first_facet")
             and args.get("sort")
-            and args["factor_cols"]
-            and next(iter(args["sort"])) == args["factor_cols"][0]
+            and args["facet_dims"]
+            and next(iter(args["sort"])) == args["facet_dims"][0]
         ):
             args.pop("sort", None)
 
@@ -477,7 +477,7 @@ with st.sidebar:  # .expander("Select dimensions"):
     st_js(f"localStorage.setItem('session_state','{json.dumps(dict(st.session_state)).replace("'", "\\'")}');")
 
     # Make all dimensions explicit now that plot is selected (as that can affect the factor columns)
-    args["factor_cols"] = impute_factor_cols(args, c_meta, plot_meta)
+    args["facet_dims"] = impute_facet_dims(args, c_meta, plot_meta)
 
     import pprint
 
@@ -508,7 +508,7 @@ if sdb and getattr(getattr(sdb, "uam", None), "admin", False):
 matrix_form = False  # (args['plot'] == 'geoplot')
 
 # Determine if one of the facets is input_file
-input_files_facet = "input_file" in args.get("factor_cols", [])
+input_files_facet = "input_file" in args.get("facet_dims", [])
 
 # Create columns, one per input file
 if not input_files_facet:
@@ -527,7 +527,7 @@ elif input_files_facet:
         df, fargs = loaded[ifile]["data"], args.copy()
         ifile_cols = list(loaded[ifile]["columns"])  # type: ignore[arg-type]
         fargs["filter"] = {k: v for k, v in fargs["filter"].items() if k in ifile_cols or k in q_groups}
-        fargs["factor_cols"] = [f for f in fargs["factor_cols"] if f != "input_file"]
+        fargs["facet_dims"] = [f for f in fargs["facet_dims"] if f != "input_file"]
         ppd = soft_validate(fargs, PlotDescriptor)
         pi = pp_transform_data(df, raw_first_data_meta, ppd)
         dfs.append(pi.data)
@@ -657,7 +657,7 @@ else:
                     if st.button("Import Spec", width="stretch"):
                         _import_modal()
 
-                    name = f"{args['res_col']}_{'_'.join(args['factor_cols']) if args['factor_cols'] else 'all'}"
+                    name = f"{args['res_col']}_{'_'.join(args['facet_dims']) if args['facet_dims'] else 'all'}"
                     chart_source = (
                         deepcopy(st.session_state["custom_spec"]) if st.session_state.get("custom_spec") else plot
                     )

--- a/salk_toolkit/validation.py
+++ b/salk_toolkit/validation.py
@@ -62,6 +62,7 @@ from typing import (
     TypeAlias,
 )
 from pydantic import (
+    AliasChoices,
     BaseModel,
     ConfigDict,
     Field,
@@ -712,7 +713,8 @@ class PlotDescriptor(PBase):
     # Main parameters
     plot: str  # Registered plot type (see `salk_toolkit.plots`)
     res_col: str  # Response column or question block name to visualise
-    factor_cols: List[str] = []  # Facet dimensions applied to the plot
+    # Facet dimensions applied to the plot ("factor_cols" accepted as a legacy key)
+    facet_dims: List[str] = Field(default=[], validation_alias=AliasChoices("facet_dims", "factor_cols"))
     filter: FilterSpec = {}  # Column filters applied before aggregation
 
     # Plotting choices

--- a/tests/test_plot_payload.py
+++ b/tests/test_plot_payload.py
@@ -72,7 +72,7 @@ def ppd_two_factors(registered_two_factor_plot):
     return PlotDescriptor(
         plot=registered_two_factor_plot,
         res_col="score",
-        factor_cols=["group.a", "group.b"],
+        facet_dims=["group.a", "group.b"],
     )
 
 
@@ -99,7 +99,7 @@ def test_dry_run_escape_labels_true_escapes_outer_factors(small_pi_fixture, ppd_
 def ppd_columns():
     """A PlotDescriptor targeting the real `columns` plot."""
 
-    return PlotDescriptor(plot="columns", res_col="score", factor_cols=["group.a", "group.b"])
+    return PlotDescriptor(plot="columns", res_col="score", facet_dims=["group.a", "group.b"])
 
 
 def test_payload_shape_columns(small_pi_fixture, ppd_columns):
@@ -142,7 +142,7 @@ def test_payload_fallback_covers_non_payload_plot(small_pi_fixture):
 
     try:
         assert pp.get_plot_meta("__test_fallback_plot").payload is False
-        ppd = PlotDescriptor(plot="__test_fallback_plot", res_col="score", factor_cols=["group.a", "group.b"])
+        ppd = PlotDescriptor(plot="__test_fallback_plot", res_col="score", facet_dims=["group.a", "group.b"])
         pl = pp.create_plot_payload(small_pi_fixture, ppd)
         # every cell carries the frame pulled off the chart's `.data`
         for row in pl["cells"]:
@@ -207,7 +207,7 @@ def ppd_mutating_two_factors(registered_mutating_two_factor_plot):
     ppd = PlotDescriptor(
         plot=plot_name,
         res_col="score",
-        factor_cols=["group.a", "group.b"],
+        facet_dims=["group.a", "group.b"],
         internal_facet=1,
     )
     return ppd, seen_n_facets
@@ -269,7 +269,7 @@ def likert_cell_pi_and_ppd():
     )
     col_meta = {"agree": GroupOrColumnMeta(categories=cats, ordered=True, likert=True, neutral_middle="Neutral")}
     pi = PlotInput(data=data, col_meta=col_meta, value_col="share")
-    ppd = PlotDescriptor(plot="likert_bars", res_col="share", factor_cols=["agree"], internal_facet=True)
+    ppd = PlotDescriptor(plot="likert_bars", res_col="share", facet_dims=["agree"], internal_facet=True)
     return pi, ppd
 
 
@@ -322,7 +322,7 @@ def test_payload_likert_bars_faceted_no_crash():
         "gender": GroupOrColumnMeta(categories=["Male", "Female"]),
     }
     pi = PlotInput(data=data, col_meta=col_meta, value_col="share")
-    ppd = PlotDescriptor(plot="likert_bars", res_col="share", factor_cols=["agree", "gender"])
+    ppd = PlotDescriptor(plot="likert_bars", res_col="share", facet_dims=["agree", "gender"])
 
     pl = pp.create_plot_payload(pi, ppd)
 
@@ -350,7 +350,7 @@ def matrix_cell_pi_and_ppd():
         }
     )
     pi = PlotInput(data=data, col_meta={}, value_col="val")
-    ppd = PlotDescriptor(plot="matrix", res_col="val", factor_cols=["row", "col"], internal_facet=True)
+    ppd = PlotDescriptor(plot="matrix", res_col="val", facet_dims=["row", "col"], internal_facet=True)
     return pi, ppd
 
 
@@ -398,7 +398,7 @@ def boxplot_cell_pi_and_ppd():
         )
     }
     pi = PlotInput(data=data, col_meta=col_meta, value_col="score")
-    ppd = PlotDescriptor(plot="boxplots", res_col="score", factor_cols=["group"], internal_facet=True)
+    ppd = PlotDescriptor(plot="boxplots", res_col="score", facet_dims=["group"], internal_facet=True)
     return pi, ppd
 
 
@@ -448,7 +448,7 @@ def marimekko_cell_pi_and_ppd():
         }
     )
     pi = PlotInput(data=data, col_meta={}, value_col="val")
-    ppd = PlotDescriptor(plot="marimekko", res_col="val", factor_cols=["row", "col"], internal_facet=True)
+    ppd = PlotDescriptor(plot="marimekko", res_col="val", facet_dims=["row", "col"], internal_facet=True)
     return pi, ppd
 
 
@@ -490,7 +490,7 @@ def line_cell_pi_and_ppd():
     )
     col_meta = {"level": GroupOrColumnMeta(categories=cats, ordered=True)}
     pi = PlotInput(data=data, col_meta=col_meta, value_col="share")
-    ppd = PlotDescriptor(plot="line", res_col="share", factor_cols=["level"], internal_facet=True)
+    ppd = PlotDescriptor(plot="line", res_col="share", facet_dims=["level"], internal_facet=True)
     return pi, ppd
 
 
@@ -512,7 +512,7 @@ def lines_cell_pi_and_ppd():
         "stage": GroupOrColumnMeta(categories=stages, ordered=True),
     }
     pi = PlotInput(data=data, col_meta=col_meta, value_col="share")
-    ppd = PlotDescriptor(plot="lines", res_col="share", factor_cols=["group", "stage"], internal_facet=True)
+    ppd = PlotDescriptor(plot="lines", res_col="share", facet_dims=["group", "stage"], internal_facet=True)
     return pi, ppd
 
 
@@ -572,7 +572,7 @@ def density_cell_pi_and_ppd():
     )
     col_meta = {"group": GroupOrColumnMeta(categories=cats)}
     pi = PlotInput(data=data, col_meta=col_meta, value_col="score")
-    ppd = PlotDescriptor(plot="density-raw", res_col="score", factor_cols=["group"], internal_facet=True)
+    ppd = PlotDescriptor(plot="density-raw", res_col="score", facet_dims=["group"], internal_facet=True)
     return pi, ppd
 
 
@@ -660,7 +660,7 @@ def test_density_categorical_input_typed_error():
     cats = ["Low", "Mid", "High"]
     data = pd.DataFrame({"answer": pd.Categorical(cats * 4, categories=cats, ordered=True)})
     pi = PlotInput(data=data, col_meta={}, value_col="answer")
-    ppd = PlotDescriptor(plot="density-raw", res_col="answer", factor_cols=[])
+    ppd = PlotDescriptor(plot="density-raw", res_col="answer", facet_dims=[])
 
     with pytest.raises(ValueError, match="continuous"):
         pp.create_plot(pi, ppd, width=400)
@@ -687,7 +687,7 @@ def geoplot_cell_pi_and_ppd():
         )
     }
     pi = PlotInput(data=data, col_meta=col_meta, value_col="score")
-    ppd = PlotDescriptor(plot="geoplot", res_col="score", factor_cols=["region"], internal_facet=True)
+    ppd = PlotDescriptor(plot="geoplot", res_col="score", facet_dims=["region"], internal_facet=True)
     return pi, ppd
 
 
@@ -764,7 +764,7 @@ def geobest_cell_pi_and_ppd():
         ),
     }
     pi = PlotInput(data=data, col_meta=col_meta, value_col="score")
-    ppd = PlotDescriptor(plot="geobest", res_col="score", factor_cols=["candidate", "region"], internal_facet=True)
+    ppd = PlotDescriptor(plot="geobest", res_col="score", facet_dims=["candidate", "region"], internal_facet=True)
     return pi, ppd
 
 
@@ -859,7 +859,7 @@ def barbell_cell_pi_and_ppd():
         "group": GroupOrColumnMeta(categories=groups, colors={"Group A": "#c00000", "Group B": "#00c000"}),
     }
     pi = PlotInput(data=data, col_meta=col_meta, value_col="score")
-    ppd = PlotDescriptor(plot="barbell", res_col="score", factor_cols=["question", "group"], internal_facet=True)
+    ppd = PlotDescriptor(plot="barbell", res_col="score", facet_dims=["question", "group"], internal_facet=True)
     return pi, ppd
 
 
@@ -912,7 +912,7 @@ def maxdiff_cell_pi_and_ppd():
         }
     )
     pi = PlotInput(data=data, col_meta={}, value_col="score")
-    ppd = PlotDescriptor(plot="maxdiff", res_col="score", factor_cols=["topic"], internal_facet=True)
+    ppd = PlotDescriptor(plot="maxdiff", res_col="score", facet_dims=["topic"], internal_facet=True)
     return pi, ppd
 
 
@@ -979,14 +979,14 @@ def test_matching_plots_maxdiff_requires_continuous_res_col():
     )
 
     categorical_matches = matching_plots(
-        {"res_col": "party", "factor_cols": ["topic"], "plot": "maxdiff"}, df, data_meta, details=True
+        {"res_col": "party", "facet_dims": ["topic"], "plot": "maxdiff"}, df, data_meta, details=True
     )
     priority, reasons = categorical_matches["maxdiff"]
     assert priority < 0
     assert "continuous_only" in reasons
 
     continuous_matches = matching_plots(
-        {"res_col": "score", "factor_cols": ["topic"], "plot": "maxdiff"}, df, data_meta, details=True
+        {"res_col": "score", "facet_dims": ["topic"], "plot": "maxdiff"}, df, data_meta, details=True
     )
     priority2, reasons2 = continuous_matches["maxdiff"]
     assert priority2 >= 0
@@ -1023,7 +1023,7 @@ def election_pi_and_ppd():
         ),
     }
     pi = PlotInput(data=data, col_meta=col_meta, value_col="support")
-    ppd = PlotDescriptor(plot="mandate_plot", res_col="support", factor_cols=["party", "district"], internal_facet=True)
+    ppd = PlotDescriptor(plot="mandate_plot", res_col="support", facet_dims=["party", "district"], internal_facet=True)
     return pi, ppd
 
 
@@ -1124,7 +1124,7 @@ def test_payload_carries_per_cell_scale_for_faceted_geo(geoplot_cell_pi_and_ppd)
     )
     party_meta = GroupOrColumnMeta(categories=parties)
     pi = pi.model_copy(update={"data": data, "col_meta": {**pi.col_meta, "party": party_meta}})
-    ppd = ppd.model_copy(update={"factor_cols": ["region", "party"]})
+    ppd = ppd.model_copy(update={"facet_dims": ["region", "party"]})
 
     pl = pp.create_plot_payload(pi, ppd)
     cells = [c for row in pl["cells"] for c in row]

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -268,7 +268,7 @@ class TestPlots:
         """Test basic boxplots."""
         config = {
             "res_col": "party_preference",
-            "factor_cols": ["age_group"],
+            "facet_dims": ["age_group"],
             "filter": {},
             "plot": "boxplots",
             "internal_facet": True,
@@ -279,7 +279,7 @@ class TestPlots:
         """Test raw boxplots."""
         config = {
             "res_col": "EKRE",
-            "factor_cols": ["age_group"],
+            "facet_dims": ["age_group"],
             "filter": {},
             "plot": "boxplots-raw",
             "internal_facet": True,
@@ -290,7 +290,7 @@ class TestPlots:
         """Test basic column plots."""
         config = {
             "res_col": "e-valimised",
-            "factor_cols": ["nationality"],
+            "facet_dims": ["nationality"],
             "filter": {},
             "plot": "columns",
             "internal_facet": True,
@@ -301,7 +301,7 @@ class TestPlots:
         """Test column plots with thermometer data."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["nationality"],
+            "facet_dims": ["nationality"],
             "filter": {},
             "plot": "columns",
             "internal_facet": True,
@@ -312,7 +312,7 @@ class TestPlots:
         """Test column plot with custom aggregation and sorting."""
         config = {
             "res_col": "EKRE",
-            "factor_cols": ["nationality"],
+            "facet_dims": ["nationality"],
             "filter": {},
             "plot": "columns",
             "internal_facet": True,
@@ -326,7 +326,7 @@ class TestPlots:
         """Test stacked column plots."""
         config = {
             "res_col": "party_preference",
-            "factor_cols": ["EKRE"],
+            "facet_dims": ["EKRE"],
             "internal_facet": True,
             "plot": "stacked_columns",
             "plot_args": {"normalized": False},
@@ -338,7 +338,7 @@ class TestPlots:
         """Test difference column plots."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["age_group"],
+            "facet_dims": ["age_group"],
             "filter": {"age_group": [None, "25-34", "35-44"]},
             "plot": "diff_columns",
             "internal_facet": True,
@@ -350,7 +350,7 @@ class TestPlots:
         """Test mass plot."""
         config = {
             "res_col": "trust",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "massplot",
             "internal_facet": True,
@@ -362,7 +362,7 @@ class TestPlots:
         """Test basic Likert bars."""
         config = {
             "res_col": "trust",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "likert_bars",
             "internal_facet": True,
@@ -373,7 +373,7 @@ class TestPlots:
         """Test Likert bars with no factor columns."""
         config = {
             "res_col": "valitsus",
-            "factor_cols": [],
+            "facet_dims": [],
             "filter": {},
             "plot": "likert_bars",
             "internal_facet": True,
@@ -384,7 +384,7 @@ class TestPlots:
         """Test raw density plot with stacking."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "density-raw",
             "plot_args": {"stacked": True},
@@ -396,7 +396,7 @@ class TestPlots:
         """Test raw violin plot."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "violin-raw",
             "sort": {"question": False},
@@ -408,7 +408,7 @@ class TestPlots:
         """Test basic matrix plot."""
         config = {
             "res_col": "party_preference",
-            "factor_cols": ["age_group"],
+            "facet_dims": ["age_group"],
             "filter": {},
             "plot": "matrix",
             "internal_facet": True,
@@ -419,7 +419,7 @@ class TestPlots:
         """Test matrix plot with thermometer data."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "matrix",
             "internal_facet": True,
@@ -430,7 +430,7 @@ class TestPlots:
         """Test matrix plot with reordering."""
         config = {
             "res_col": "issues",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "matrix",
             "plot_args": {"reorder": True},
@@ -444,7 +444,7 @@ class TestPlots:
         """Test correlation matrix plot."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": [],
+            "facet_dims": [],
             "filter": {},
             "plot": "corr_matrix",
             "internal_facet": True,
@@ -455,7 +455,7 @@ class TestPlots:
         """Test line plot with smoothing."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["education"],
+            "facet_dims": ["education"],
             "filter": {},
             "plot": "lines",
             "internal_facet": True,
@@ -468,7 +468,7 @@ class TestPlots:
         """Test line plot with smoothing."""
         config = {
             "res_col": "party_preference",
-            "factor_cols": ["td"],
+            "facet_dims": ["td"],
             "filter": {},
             "plot": "lines",
             "internal_facet": True,
@@ -479,7 +479,7 @@ class TestPlots:
         """Test HDI line plot."""
         config = {
             "res_col": "party_preference",
-            "factor_cols": ["age_group", "nationality"],
+            "facet_dims": ["age_group", "nationality"],
             "filter": {},
             "plot": "lines_hdi",
             "internal_facet": True,
@@ -490,7 +490,7 @@ class TestPlots:
         """Test smooth area plot."""
         config = {
             "res_col": "party_preference",
-            "factor_cols": ["education", "gender"],
+            "facet_dims": ["education", "gender"],
             "filter": {},
             "plot": "area_smooth",
             "internal_facet": True,
@@ -501,7 +501,7 @@ class TestPlots:
         """Test Likert radicalization/polarization plot."""
         config = {
             "res_col": "referendum",
-            "factor_cols": ["electoral_district"],
+            "facet_dims": ["electoral_district"],
             "internal_facet": True,
             "plot": "likert_rad_pol",
             "filter": {},
@@ -513,7 +513,7 @@ class TestPlots:
         """Test barbell plot."""
         config = {
             "res_col": "trust",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "barbell",
             "internal_facet": True,
@@ -528,7 +528,7 @@ class TestPlots:
 
         config = {
             "res_col": "EKRE",
-            "factor_cols": ["electoral_district"],
+            "facet_dims": ["electoral_district"],
             "filter": {},
             "plot": "geoplot",
             "internal_facet": True,
@@ -547,7 +547,7 @@ class TestPlots:
             pytest.skip("Data metadata not available for geoplot test")
 
         config = {
-            "factor_cols": ["unit", "party_preference"],
+            "facet_dims": ["unit", "party_preference"],
             "internal_facet": True,
             "plot": "geoplot",
             "plot_args": {"separate_axes": True},
@@ -566,7 +566,7 @@ class TestPlots:
         """Test facet distribution plot."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "facet_dist",
             "internal_facet": True,
@@ -576,7 +576,7 @@ class TestPlots:
     def test_max_diff(self, recompute):
         """Test max_diff plot."""
         config = {
-            "factor_cols": ["question"],
+            "facet_dims": ["question"],
             "filter": {},
             "internal_facet": True,
             "plot": "maxdiff",
@@ -595,7 +595,7 @@ class TestPlots:
         ldf, full_meta = read_parquet_with_metadata(str(self.data_file), lazy=True)
         assert full_meta is not None and full_meta.data is not None
         config = {
-            "factor_cols": ["question"],
+            "facet_dims": ["question"],
             "filter": {},
             "internal_facet": True,
             "plot": "maxdiff",
@@ -613,7 +613,7 @@ class TestPlots:
         """Test ordered population plot."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "ordered_population",
             "internal_facet": True,
@@ -625,7 +625,7 @@ class TestPlots:
         """Sampled ordered population emits real filtered sample rows, not 200 slice summaries."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {"party_preference": ["EKRE", "SDE"]},
             "plot": "ordered_population_sampled",
             "internal_facet": True,
@@ -651,7 +651,7 @@ class TestPlots:
         """The sampled plot must cap filtered raw rows before group observations are melted."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {"party_preference": ["EKRE", "SDE"]},
             "plot": "ordered_population_sampled",
             "internal_facet": True,
@@ -665,7 +665,7 @@ class TestPlots:
         """The implicit sampled plot cap should stay small enough for interactive charts."""
         config = {
             "res_col": "thermometer",
-            "factor_cols": ["party_preference"],
+            "facet_dims": ["party_preference"],
             "filter": {},
             "plot": "ordered_population_sampled",
             "internal_facet": True,
@@ -678,7 +678,7 @@ class TestPlots:
         """Test Marimekko plot."""
         config = {
             "res_col": "trust",
-            "factor_cols": ["question", "party_preference"],
+            "facet_dims": ["question", "party_preference"],
             "filter": {},
             "plot": "marimekko",
             "internal_facet": True,
@@ -737,7 +737,7 @@ class TestPlots:
         """Test boxplots with result conversion."""
         config = {
             "res_col": "age_group",
-            "factor_cols": ["gender"],
+            "facet_dims": ["gender"],
             "filter": {},
             "plot": "boxplots",
             "internal_facet": True,
@@ -750,7 +750,7 @@ class TestPlots:
         """Test HDI lines with numerical values and custom formatting."""
         config = {
             "res_col": "valitsus",
-            "factor_cols": ["party_preference", "age_group"],
+            "facet_dims": ["party_preference", "age_group"],
             # Isamaa HDI has multiple close options so excluding it
             "filter": {"party_preference": ["Keskerakond", "Reformierakond", "SDE", "EKRE"]},
             "convert_res": "continuous",
@@ -766,7 +766,7 @@ class TestPlots:
         """Test Likert bars with metadata."""
         config = {
             "res_col": "trust",
-            "factor_cols": ["gender", "age_group"],
+            "facet_dims": ["gender", "age_group"],
             "filter": {},
             "plot": "likert_bars",
             "internal_facet": True,
@@ -781,7 +781,7 @@ class TestPlots:
         """Test that appropriate error is raised for missing data file."""
         config = {
             "res_col": "party_preference",
-            "factor_cols": ["age_group"],
+            "facet_dims": ["age_group"],
             "filter": {},
             "plot": "boxplots",
             "internal_facet": True,
@@ -799,7 +799,7 @@ class TestPlots:
         """Test behavior with invalid column names."""
         config = {
             "res_col": "nonexistent_column",
-            "factor_cols": ["age_group"],
+            "facet_dims": ["age_group"],
             "filter": {},
             "plot": "boxplots",
             "internal_facet": True,

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -15,7 +15,7 @@ from salk_toolkit.pp import (
     _calculate_priority as calculate_priority,
     _transform_cont,
     get_plot_fn,
-    impute_factor_cols,
+    impute_facet_dims,
     matching_plots,
     PlotMeta,
     registry,
@@ -72,7 +72,7 @@ def test_update_data_meta_with_pp_desc_adds_res_meta_and_updates_columns() -> No
     pp_desc_dict = {
         "plot": "test_plot",
         "res_col": "likert_score",
-        "factor_cols": ["gender"],
+        "facet_dims": ["gender"],
         "res_meta": {
             "name": "likert_question",
             "scale": {"col_prefix": "likert_"},
@@ -184,7 +184,7 @@ def test_matching_plots_respects_hidden_flag(registry_guard: Any) -> None:
     data_meta = _make_basic_meta()
     pp_desc = {
         "res_col": "res",
-        "factor_cols": ["facet"],
+        "facet_dims": ["facet"],
         "plot": "visible_plot",
     }
 
@@ -201,8 +201,8 @@ def test_matching_plots_respects_hidden_flag(registry_guard: Any) -> None:
     stk_deregister("hidden_plot")
 
 
-def test_impute_factor_cols_handles_categorical_and_continuous_cases() -> None:
-    """`impute_factor_cols` should handle categorical and continuous conversions."""
+def test_impute_facet_dims_handles_categorical_and_continuous_cases() -> None:
+    """`impute_facet_dims` should handle categorical and continuous conversions."""
     col_meta = {
         "res_group": GroupOrColumnMeta.model_validate({"columns": ["res_variant"], "categories": ["Yes", "No"]}),
         "res_variant": GroupOrColumnMeta.model_validate({"categories": ["Yes", "No"]}),
@@ -213,18 +213,18 @@ def test_impute_factor_cols_handles_categorical_and_continuous_cases() -> None:
     categorical_desc = {
         "plot": "test_plot",
         "res_col": "res_group",
-        "factor_cols": ["region"],
+        "facet_dims": ["region"],
     }
-    categorical_factors = impute_factor_cols(categorical_desc, col_meta)
+    categorical_factors = impute_facet_dims(categorical_desc, col_meta)
     assert categorical_factors == ["res_group", "region", "question"]
 
     continuous_desc = {
         "plot": "test_plot",
         "res_col": "res_group",
-        "factor_cols": ["region"],
+        "facet_dims": ["region"],
         "convert_res": "continuous",
     }
-    continuous_factors = impute_factor_cols(continuous_desc, col_meta)
+    continuous_factors = impute_facet_dims(continuous_desc, col_meta)
     assert continuous_factors == ["question", "region"]
 
 
@@ -325,3 +325,14 @@ def test_get_plot_fn_legacy_wrapper_builds_chart() -> None:
     )
 
     assert hasattr(plot, "to_dict")
+
+
+def test_plot_descriptor_accepts_legacy_factor_cols_key():
+    """Stored descriptors (dashboards, URLs) use the legacy "factor_cols" key."""
+    from salk_toolkit.pp import impute_factor_cols, impute_facet_dims
+    from salk_toolkit.validation import PlotDescriptor
+
+    d = PlotDescriptor.model_validate({"plot": "columns", "res_col": "x", "factor_cols": ["age"]})
+    assert d.facet_dims == ["age"]
+    assert "facet_dims" in d.model_dump()
+    assert impute_factor_cols is impute_facet_dims


### PR DESCRIPTION
Stacked on #59. Renames the request/pipeline vocabulary so "factor" no longer means both *categorical plot dimension* and *latent factor model* in the same request:

- `PlotDescriptor.facet_dims` — the legacy `"factor_cols"` key is accepted via a validation alias (stored dashboard descriptors, old frontend requests, sip test utils all keep validating); `model_dump()` emits `facet_dims`.
- `impute_facet_dims` — module-level `impute_factor_cols` alias kept for external callers (dms-plots-api imports it; its own rename rides the next re-vendor).
- `_inner_outer_facets`, local variables, stk_explorer dict keys, and tests swept. stk_explorer rebuilds its descriptor from widget state every rerun, so no legacy-state normalization is needed there.
- New test: legacy-key descriptor validates, dumps as `facet_dims`, alias identity.

Deliberately NOT renamed (follow-ups): `PlotInput.outer_factors` + the payload wire key `outer_factors` (a deployed contract — dms reads it; removable entirely once dms switches to `facet_dims[n_inner:]`), and `@stk_plot(factor_columns=…)` plot-meta vocabulary.

272 tests + ruff + pyright clean (the env-sensitive `test_facet_dist` KDE flake deselected, fails identically on origin/main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)