### PR TITLE
Map categories without num_values to null in continuous conversion

### DIFF
--- a/salk_toolkit/pp.py
+++ b/salk_toolkit/pp.py
@@ -1151,8 +1151,9 @@ def pp_transform_data(
             categories = res_meta.categories or []
             nvals = nvals or []
             cmap = dict(zip(categories, nvals))
+            # Categories without a numeric value (e.g. nonresponse) become null, not a failed cast
             filtered_df = filtered_df.with_columns(
-                pl.col(rc).cast(pl.String).replace(cmap).cast(pl.Float32).fill_nan(None)
+                pl.col(rc).cast(pl.String).replace_strict(cmap, default=None, return_dtype=pl.Float32).fill_nan(None)
             )
             nvals = np.array(nvals, dtype="float")  # To handle null as nan
             val_range = (np.nanmin(nvals), np.nanmax(nvals)) if len(nvals) > 0 else (0.0, 1.0)
@@ -1354,6 +1355,8 @@ def _wrangle_data(
                 raise Exception(f"Unknown agg_fn: {agg_fn}")
 
         else:  # Continuous
+            # Null values (e.g. nonresponse converted to continuous) don't count toward any aggregate
+            raw_df = raw_df.filter(pl.col(res_col).is_not_null())
             if agg_fn in [
                 "mean",
                 "sum",

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -17,6 +17,7 @@ from salk_toolkit.pp import (
     get_plot_fn,
     impute_factor_cols,
     matching_plots,
+    pp_transform_data,
     PlotMeta,
     registry,
     registry_meta,
@@ -302,6 +303,71 @@ def test_transform_cont_full_streaming_pipeline(tmp_path) -> None:
 
     result = lf.collect(engine="streaming")
     assert result.shape == (len(cols), 6)
+
+
+def test_convert_res_continuous_maps_unmapped_nonresponse_to_null() -> None:
+    """Categories beyond num_values (e.g. nonresponse) become null instead of crashing the cast."""
+    cats = [
+        "Do not agree at all",
+        "Tend to disagree",
+        "Tend to agree",
+        "Agree completely",
+        "Don't know",
+        "No answer",
+    ]
+    data_meta = make_data_meta(
+        {
+            "structure": [
+                {
+                    "name": "demographics",
+                    "scale": {},
+                    "columns": [["gender", {"categories": ["Female", "Male"]}]],
+                },
+                {
+                    "name": "values",
+                    "scale": {
+                        "categories": cats,
+                        "ordered": True,
+                        "likert": True,
+                        "num_values": [-2.0, -1.0, 1.0, 2.0],
+                        "nonresponse": ["Don't know", "No answer"],
+                    },
+                    "columns": [["value_diversity", {"label": "Cultural diversity"}]],
+                },
+            ]
+        }
+    )
+    answers = (
+        ["Do not agree at all"]
+        + ["Tend to disagree"] * 2
+        + ["Tend to agree"] * 3
+        + ["Agree completely"] * 4
+        + ["Don't know"] * 2
+        + ["No answer"]
+    )
+    df = pd.DataFrame(
+        {
+            "draw": [0] * 13,
+            "gender": ["Female", "Male"] * 6 + ["Female"],
+            "value_diversity": answers,
+        }
+    )
+    ppd = soft_validate(
+        {
+            "res_col": "value_diversity",
+            "factor_cols": ["gender"],
+            "convert_res": "continuous",
+            "plot": "boxplots",
+        },
+        PlotDescriptor,
+    )
+
+    pi = pp_transform_data(pl.LazyFrame(df), data_meta, ppd)
+
+    # Nonresponse rows drop out of the aggregate: mean over substantive answers only.
+    by_gender = dict(zip(pi.data["gender"], pd.to_numeric(pi.data[pi.value_col], errors="raise")))
+    assert by_gender["Female"] == pytest.approx((-2 - 1 + 1 + 2 + 2) / 5)
+    assert by_gender["Male"] == pytest.approx((-1 + 1 + 1 + 2 + 2) / 5)
 
 
 def test_get_plot_fn_legacy_wrapper_builds_chart() -> None:


### PR DESCRIPTION
## Problem

Converting an ordered categorical to continuous crashes when the scale has more categories than `num_values` — e.g. a likert scale with `nonresponse` categories:

```
polars.exceptions.InvalidOperationError: conversion from `str` to `f32` failed in column
'_POLARS_TMP_…': ["Don't know", … "No answer"] … col("…").strict_cast(Float32)
```

Real case: modelrun 120 (`de_traum_v2`), `germany_values` — 6 categories (4 substantive + `Don't know`/`No answer` marked `nonresponse`), `num_values: [-2,-1,1,2]`.

## Root cause

`cmap = dict(zip(categories, nvals))` silently truncates to the shorter `num_values`, leaving nonresponse categories unmapped; `replace(cmap)` keeps them as strings and the subsequent strict `cast(pl.Float32)` fails.

## Fix

- `replace(cmap).cast(pl.Float32)` → `replace_strict(cmap, default=None, return_dtype=pl.Float32)`: unmapped categories become null.
- Null-filter in the continuous aggregation branch — without it null rows still counted in the weight denominator and diluted the weighted mean.

## Test

`tests/test_pp.py::test_convert_res_continuous_maps_unmapped_nonresponse_to_null` — models the germany_values case end-to-end via `pp_transform_data`; asserts no crash and that means equal the substantive-responses-only means. Written red-first against the exact production error.

Full suite: 279 passed; `test_plots.py::test_facet_dist` fails identically on clean main (pre-existing density-reference drift, unrelated).

## Validating in prod

Prod plots-api vendors salk_toolkit at image build time, so this reaches prod with the next plots-api redeploy that includes this commit. Then:

```bash
KEY=$(cat ~/.config/dms/api_key)
curl -sS -X POST https://dms.salk.ee/api/plots/plot-data \
  -H "X-API-Key: $KEY" -H "Content-Type: application/json" \
  -d '{"entity":{"kind":"modelrun","id":120},"descriptor":{"res_col":"germany_values","factor_cols":[],"convert_res":"continuous","internal_facet":true}}'
```

Before: 422 with the polars cast error. After: 200 payload. In the UI: Periskoop Explore → run 120 (de_traum_v2) → Observation `germany_values` → tick "Convert to continuous" → chart renders; means should match a hand-check that excludes Don't know / No answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)