### PR TITLE
Drop single-category outer facet dims in create_plot

### DIFF
--- a/salk_toolkit/pp.py
+++ b/salk_toolkit/pp.py
@@ -1715,7 +1715,8 @@ def create_plot(
                         plot_args[k] = _meta_to_plain(facet_meta).get(k)
 
         factor_cols = factor_cols[n_inner:]  # Leave rest for external faceting
-    pi.outer_factors = factor_cols
+    # Single-category dims add no split; drop them so colors and grid shape come from real dims
+    pi.outer_factors = [c for c in factor_cols if len(utils.get_categories(data[c].dtype)) != 1]
 
     if plot_meta.no_faceting and len(pi.outer_factors) > 0:
         return_matrix_of_plots = True

--- a/tests/test_plot_payload.py
+++ b/tests/test_plot_payload.py
@@ -96,6 +96,36 @@ def test_dry_run_escape_labels_true_escapes_outer_factors(small_pi_fixture, ppd_
 
 
 @pytest.fixture
+def degenerate_outer_pi_fixture():
+    """PlotInput where one outer dim has a single dtype category (a melted one-question block)."""
+
+    rng = np.random.default_rng(0)
+    data = pd.DataFrame(
+        {
+            "score": rng.uniform(0, 1, 9),
+            "question": pd.Categorical(["party_preference"] * 9, categories=["party_preference"]),
+            "party": pd.Categorical(np.tile(["P1", "P2", "P3"], 3), categories=["P1", "P2", "P3"]),
+        }
+    )
+    col_meta = {
+        "party": GroupOrColumnMeta(
+            categories=["P1", "P2", "P3"],
+            colors={"P1": "#111111", "P2": "#222222", "P3": "#333333"},
+        ),
+    }
+    return PlotInput(data=data, col_meta=col_meta, value_col="score")
+
+
+def test_single_category_outer_factor_dropped(degenerate_outer_pi_fixture, registered_two_factor_plot):
+    """A 1-category outer dim adds no split: drop it so colors and grid come from the real dim."""
+
+    ppd = PlotDescriptor(plot=registered_two_factor_plot, res_col="score", factor_cols=["question", "party"])
+    pi = pp.create_plot(degenerate_outer_pi_fixture, ppd, dry_run=True, escape_labels=False)
+    assert pi.outer_factors == ["party"]
+    assert set(pi.outer_colors) == {"P1", "P2", "P3"}
+
+
+@pytest.fixture
 def ppd_columns():
     """A PlotDescriptor targeting the real `columns` plot."""
 


### PR DESCRIPTION
## Problem

A single categorical column melted from a one-column block leaves a degenerate `question` dim (one category) in front of the real facet dim. For a faceted geoplot (e.g. modelrun 120, `party` × `state`) this caused two symptoms:

- **No party colours**: geoplot's gradient lookup checks only `outer_factors[0]` — the degenerate `question` dim, whose value (`party_preference`) is not a colour key — so every cell fell back to the default blue ramp. The party values that DO match colours sat in `outer_factors[1]`.
- **1×11 grid**: two outer factors produce a 2D question×party grid — one row of 11 maps.

## Fix

One line in `create_plot` (pp.py): outer factors now exclude dims with exactly **one dtype category**, applied before the colour lookup and the multi-factor merge, so both colours and layout resolve from the surviving dim.

Deliberate criterion — dtype categories, not observed values: pp never calls `remove_unused_categories`, so a user facet merely *filtered* to one value keeps its full dtype category set and is **not** dropped; only structurally degenerate dims go.

**Behaviour change (intentional):** for affected plots, grid shape changes (run 120 geoplot: 1×11 → 6×2 via geoplot's `factor_columns=2`) and cell titles lose the redundant prefix (`CDU-CSU` instead of `party_preference-CDU-CSU`).

## Tests

`tests/test_plot_payload.py::test_single_category_outer_factor_dropped` (red-first). Full suite: 279 passed, 1 skipped; `test_plots.py::test_facet_dist` fails identically on clean main (pre-existing density-reference drift, unrelated). The existing geoplot colour reference test passes.

## Validating in prod

Prod plots-api vendors salk_toolkit at image build time, so this reaches prod with the next plots-api redeploy that includes this commit. Then open:

`https://dms.salk.ee/periskoop/explore?explore=120&obs=party&facets=state&plot=geoplot`

Before: 11 maps in one row, all in near-identical blue ramps. After: 2-column grid, each map in its party's gradient (CDU-CSU black, SPD red, Die Grünen green, AfD blue, nonresponse grey), titles without the `party_preference-` prefix. Or via curl, check each cell's `encoding.color.scale.range` derives from the party colour instead of the shared blue ramp:

```bash
KEY=$(cat ~/.config/dms/api_key)
curl -sS -X POST https://dms.salk.ee/api/plots/plot \
  -H "X-API-Key: $KEY" -H "Content-Type: application/json" \
  -d '{"entity":{"kind":"modelrun","id":120},"descriptor":{"res_col":"party","factor_cols":["state"],"plot":"geoplot","internal_facet":true},"width":800}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)