### PR TITLE
Mint fresh row ids when a hook rebuilds the frame; exclusions before postprocessing

### DIFF
--- a/salk_toolkit/io/core.py
+++ b/salk_toolkit/io/core.py
@@ -1,6 +1,7 @@
 """Core types shared across the io package: the Dataset/SourceBundle value objects,
 processing options, the hook execution environment, and shared series helpers."""
 
+import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import NamedTuple, cast
@@ -129,6 +130,23 @@ def assert_row_id_intact(df: pd.DataFrame, context: str) -> None:
     if col.duplicated().any():
         dups = list(col[col.duplicated()].unique()[:5])
         raise ValueError(f"{context} produced duplicate row ids, e.g. {dups} - were rows added programmatically?")
+
+
+def restore_or_assert_row_id(df: pd.DataFrame, context: str, file_code: str = "PP") -> pd.DataFrame:
+    """Re-mint row ids when a hook legitimately rebuilt the frame; otherwise assert them intact.
+
+    Aggregating hooks (e.g. a census ``groupby(...).sum()``) cannot preserve source-row
+    identity - the output rows get fresh positional ``{file_code}::{i}`` ids with a warning.
+    """
+    if ROW_ID not in df.columns:
+        warnings.warn(
+            f"{context} rebuilt the frame without '{ROW_ID}' (e.g. via groupby); minting fresh positional row ids",
+            UserWarning,
+            stacklevel=2,
+        )
+        return mint_positional_row_id(df, file_code)
+    assert_row_id_intact(df, context)
+    return df
 
 
 def finalize_row_index(df: pd.DataFrame) -> pd.DataFrame:

--- a/salk_toolkit/io/datasets.py
+++ b/salk_toolkit/io/datasets.py
@@ -32,9 +32,9 @@ from salk_toolkit.io.core import (
     Dataset,
     ProcessOpts,
     _str_from_list,
-    assert_row_id_intact,
     finalize_row_index,
     mint_positional_row_id,
+    restore_or_assert_row_id,
 )
 from salk_toolkit.io.meta import _is_categorical, fix_df_with_meta
 from salk_toolkit.io.sources import _load_data_files, _load_dataset, _process_annotated_data
@@ -474,7 +474,7 @@ def read_and_process_data(
         globs = {"pd": pd, "np": np, "sp": sp, "stk": stk, "df": df, **einfo, **constants}
         if desc_obj.preprocessing:
             exec(_str_from_list(desc_obj.preprocessing), globs)
-            assert_row_id_intact(globs["df"], "DataDescription preprocessing")
+            globs["df"] = restore_or_assert_row_id(globs["df"], "DataDescription preprocessing")
 
         if desc_obj.filter:
             globs["df"] = globs["df"][eval(desc_obj.filter, globs)]
@@ -483,7 +483,7 @@ def read_and_process_data(
             globs["df"] = _perform_merges(globs["df"], desc_obj.merge, constants, meta_obj)
         if desc_obj.postprocessing and not skip_postprocessing:
             exec(_str_from_list(desc_obj.postprocessing), globs)
-            assert_row_id_intact(globs["df"], "DataDescription postprocessing")
+            globs["df"] = restore_or_assert_row_id(globs["df"], "DataDescription postprocessing")
         df = globs["df"]
 
     # Stable, unique, deterministic index at the return boundary.

--- a/salk_toolkit/io/pipeline.py
+++ b/salk_toolkit/io/pipeline.py
@@ -22,8 +22,8 @@ from salk_toolkit.io.core import (
     SourceBundle,
     _deterministic_categories_and_values,
     _is_series_of_lists,
-    assert_row_id_intact,
     finalize_row_index,
+    restore_or_assert_row_id,
 )
 from salk_toolkit.io.create_blocks import _create_new_columns_and_metas
 from salk_toolkit.io.meta import _fix_meta_categories
@@ -319,20 +319,23 @@ def process(bundle: SourceBundle, meta_obj: DataMeta, opts: ProcessOpts) -> Data
             bundle.frames[fc] = hooks.exec_df(
                 meta_obj.preprocessing, bundle.frames[fc], file_code=fc, file_name=file_names[fc]
             )
-            assert_row_id_intact(bundle.frames[fc], f"preprocessing of {fc}")
+            bundle.frames[fc] = restore_or_assert_row_id(bundle.frames[fc], f"preprocessing of {fc}", file_code=fc)
 
     # File provenance columns must survive end-to-end (also if preprocessing dropped/mutated them)
     meta_obj = _inject_files_block(bundle, meta_obj, file_names)
 
     ndf_df, meta_obj = _build_columns(bundle, meta_obj, hooks)
 
+    # Exclusions run before the postprocessing hook: excluded rows must not feed its
+    # aggregates, and ids the hook re-mints have no id-keyed consumers left downstream
+    ndf_df = _apply_exclusions(ndf_df, meta_obj, opts)
+
     if meta_obj.postprocessing is not None:
         ndf_df = hooks.exec_df(meta_obj.postprocessing, ndf_df)
-        assert_row_id_intact(ndf_df, "postprocessing")
+        ndf_df = restore_or_assert_row_id(ndf_df, "postprocessing")
 
     # Fix categories after postprocessing; also replaces "infer" with the actual categories
     meta_obj = _fix_meta_categories(meta_obj, ndf_df, warnings=True)
 
-    ndf_df = _apply_exclusions(ndf_df, meta_obj, opts)
     # Stable, unique, deterministic index at the return boundary
     return Dataset(finalize_row_index(ndf_df), meta_obj)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1797,6 +1797,60 @@ class TestAdvancedFeatures:
         assert "final" in df.columns
         assert df["final"].tolist() == [101, 102, 103, 104, 105]
 
+    def test_postprocessing_aggregation_mints_fresh_row_ids(self, csv_file, meta_file):
+        """An aggregating postprocessing (census-style groupby) gets fresh positional row ids + a warning."""
+        df_to_csv(pd.DataFrame({"grp": ["a", "a", "b", "b", "b"], "N": [1, 2, 3, 4, 5]}), csv_file)
+
+        meta = {
+            "file": "test.csv",
+            "structure": [{"name": "t", "columns": [["grp", {"categories": ["a", "b"]}], ["N", {"continuous": True}]]}],
+            "postprocessing": "df = df.groupby(['grp'], as_index=False, observed=True)['N'].sum()",
+        }
+        write_json(meta_file, meta)
+
+        with pytest.warns(UserWarning, match="minting fresh positional row ids"):
+            df = read_annotated_data(str(meta_file))
+
+        assert df.index.name == "row_id"
+        assert list(df.index) == ["PP::0", "PP::1"]
+        assert df["N"].tolist() == [3, 12]
+
+    def test_preprocessing_aggregation_mints_fresh_row_ids(self, csv_file, meta_file):
+        """An aggregating per-file preprocessing gets fresh positional ids under that file's own code."""
+        df_to_csv(pd.DataFrame({"grp": ["a", "a", "b", "b", "b"], "N": [1, 2, 3, 4, 5]}), csv_file)
+
+        meta = {
+            "file": "test.csv",
+            "structure": [{"name": "t", "columns": [["grp", {"categories": ["a", "b"]}], ["N", {"continuous": True}]]}],
+            "preprocessing": "df = df.groupby(['grp'], as_index=False, observed=True)['N'].sum()",
+        }
+        write_json(meta_file, meta)
+
+        with pytest.warns(UserWarning, match="minting fresh positional row ids"):
+            df = read_annotated_data(str(meta_file))
+
+        assert df.index.name == "row_id"
+        assert list(df.index) == ["F0::0", "F0::1"]
+        assert df["N"].tolist() == [3, 12]
+
+    def test_exclusions_apply_before_postprocessing_aggregation(self, csv_file, meta_file):
+        """Excluded rows are filtered before the postprocessing hook, so they never feed its aggregates."""
+        df_to_csv(pd.DataFrame({"grp": ["a", "a", "b"], "id": [1, 2, 3], "N": [1, 2, 4]}), csv_file)
+
+        meta = {
+            "file": "test.csv",
+            "id_col": "id",
+            "structure": [{"name": "t", "columns": [["grp", {"categories": ["a", "b"]}], ["N", {"continuous": True}]]}],
+            "excluded": [["F0::2", "bad row"]],
+            "postprocessing": "df = df.groupby(['grp'], as_index=False, observed=True)['N'].sum()",
+        }
+        write_json(meta_file, meta)
+
+        with pytest.warns(UserWarning, match="minting fresh positional row ids"):
+            df = read_annotated_data(str(meta_file))
+
+        assert df["N"].tolist() == [1, 4]  # excluded F0::2 (N=2) not baked into the 'a' aggregate
+
     def test_exclusions_handling(self, csv_file, meta_file):
         """Exclusions are keyed by the stable row_id, here derived from a declared id_col."""
         df_to_csv(pd.DataFrame({"value": [1, 2, 3, 4, 5], "id": [1, 2, 3, 4, 5]}), csv_file)


### PR DESCRIPTION
## Problem

Since #60, the row-id guards raise when a meta-level (or DataDescription-level) hook returns a frame without the `row_id` column. But an **aggregating** hook — the standard census pattern —

```json
"postprocessing": "df = df.groupby(['age_group','gender','education','urban_rural','region'], as_index=False, observed=True)['N'].sum()"
```

cannot preserve source-row identity at all: the output rows *are* new rows. Both eurobarometer census metas (`ee_census_meta.json`, `lt_census_meta.json`) that loaded fine before #60 now fail with:

```
ValueError: postprocessing removed the 'row_id' column - stable row ids must be preserved
```

## Fix

New `restore_or_assert_row_id` helper in `io/core.py`: when a hook's output has no `row_id` column, mint fresh positional `{file_code}::{i}` ids with a `UserWarning`; when the column is present, keep the strict null/duplicate assertions from #60 unchanged.

Wired into **all four** user exec-hook boundaries — the complete set of places user code can rebuild the frame:

- meta-level per-file `preprocessing` (`pipeline.py`) — mints under the file's own code (`F0::…`), so provenance stays coherent
- meta-level `postprocessing` (`pipeline.py`) — mints `PP::…`
- DataDescription `preprocessing` and `postprocessing` (`datasets.py`) — mint `PP::…`

(`transform`/`subgroup_transform` are eval-only column expressions and `filter`/`merge` preserve or subset ids, so no other sites exist.)

**Exclusions now run before the meta postprocessing hook.** Previously `_apply_exclusions` ran after it, which had two problems once minting is allowed: excluded rows were baked into the hook's aggregates before the filter ran, and freshly minted ids could never match the id-keyed `excluded` list (silent no-op). With the reorder, excluded rows never feed postprocessing aggregates and ids re-minted by the hook have no id-keyed consumers left downstream. Note: per-file `preprocessing` still runs before exclusions by nature — an aggregating *preprocessing* hook on a meta that also has `excluded` entries will get the existing "excluded row_id(s) not present" warning, since source rows no longer exist to exclude.

Behavior note from the reorder: hooks that referenced pre-exclusion rows now see the filtered frame; `original_inds` (when requested) now numbers rows before postprocessing rather than after.

## Tests

- `test_postprocessing_aggregation_mints_fresh_row_ids`: groupby postprocessing → warning + fresh unique `PP::*` index + correct aggregates
- `test_preprocessing_aggregation_mints_fresh_row_ids`: same for per-file preprocessing → `F0::*` ids
- `test_exclusions_apply_before_postprocessing_aggregation`: an excluded row's value is absent from the postprocessed aggregate

Full suite: 292 passed, 1 skipped; ruff clean; pyright clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
