### PR TITLE
geoplot: pick cell gradient from any colored outer dim, not just the first

### DIFF
--- a/salk_toolkit/plots.py
+++ b/salk_toolkit/plots.py
@@ -1748,6 +1748,9 @@ def geoplot(
         raise ValueError("geoplot requires at least one facet dimension")
 
     outer_colors = dict(p.outer_colors or {})
+    # Legacy flat shape ({value: color}): treat as the first outer dim's color dict
+    if outer_colors and not all(isinstance(v, dict) for v in outer_colors.values()):
+        outer_colors = {p.outer_factors[0]: outer_colors} if p.outer_factors else {}
     fmt = p.val_format or ".2f"
     f0 = p.facets[0]
     vr = p.value_range
@@ -1766,15 +1769,26 @@ def geoplot(
     lmi, lma = data[p.value_col].min(), data[p.value_col].max()
     mi, ma = vr if vr and not separate_axes else (lmi, lma)
 
-    # Only show maximum on legend if min and max too close together
-    [lmi, lma] if (lma - lmi) / (ma - mi) > 0.5 else [lma]
-    rel_range = [(lmi - mi) / (ma - mi), (lma - mi) / (ma - mi)]
+    # Empty cells (unpopulated outer-dim combos) and constant cells have no usable span
+    if pd.isna(ma - mi) or ma == mi:
+        if pd.isna(lmi):
+            lmi, lma, mi, ma = 0.0, 1.0, 0.0, 1.0
+        rel_range = [0.0, 1.0]
+    else:
+        rel_range = [(lmi - mi) / (ma - mi), (lma - mi) / (ma - mi)]
 
-    outer0 = p.outer_factors[0] if p.outer_factors else None
-    ofv = data[outer0].iloc[0] if outer0 else None
-    # If colors provided, create a gradient based on that
-    if p.outer_factors and outer_colors and data[p.outer_factors[0]].nunique() == 1 and ofv in outer_colors:
-        grad = utils.gradient_from_color(outer_colors[ofv], range=rel_range)
+    # An outer dim fixed to a single colored value tints this cell; outer_colors is in
+    # precedence order (observation-derived dims first), so party outranks e.g. gender
+    cell_color = next(
+        (
+            cmap[data[c].iloc[0]]
+            for c, cmap in outer_colors.items()
+            if cmap and c in data.columns and data[c].nunique() == 1 and data[c].iloc[0] in cmap
+        ),
+        None,
+    )
+    if cell_color is not None:
+        grad = utils.gradient_from_color(cell_color, range=rel_range)
         scale = {"domain": [lmi, lma], "range": grad}
     else:  # Blues for pos, reds for neg, redblue for both
         # If axis spans both directions

--- a/salk_toolkit/pp/plotting.py
+++ b/salk_toolkit/pp/plotting.py
@@ -276,12 +276,6 @@ def create_plot(
 
     pi.value_range = tuple(data[pi.value_col].agg(["min", "max"]))
 
-    pi.outer_colors = (
-        _normalize_color_dict(col_meta.get(pi.outer_factors[0], GroupOrColumnMeta()).colors or {}) or {}
-        if pi.outer_factors
-        else {}
-    )
-
     # Rename res_col if label provided (or remove prefix if present)
     value_meta = col_meta.get(pi.value_col)
     if value_meta and (value_meta.label or value_meta.col_prefix):
@@ -318,6 +312,14 @@ def create_plot(
 
     data = _translate_df(data, _tfunc)
     pi.value_col = _tfunc(pi.value_col)
+    # Per outer dim (translated name): its category color dict, in scan precedence order -
+    # observation-derived dims (cat_col, the battery question dim) first, so a plot picking a
+    # cell gradient from whichever dim the cell is fixed on prefers e.g. party over gender colors
+    obs_dims = {pi.cat_col, "question"}
+    pi.outer_colors = {
+        _tfunc(c): _normalize_color_dict(col_meta.get(c, GroupOrColumnMeta()).colors or {}) or {}
+        for c in sorted(pi.outer_factors, key=lambda c: c not in obs_dims)
+    }
     pi.outer_factors = [_tfunc(c) for c in pi.outer_factors]
 
     # If we still have more than 1 factor left, merge the rest into one so we have a 2d facet

--- a/tests/test_plot_payload.py
+++ b/tests/test_plot_payload.py
@@ -131,7 +131,8 @@ def test_single_category_outer_factor_dropped(degenerate_outer_pi_fixture, regis
     ppd = PlotDescriptor(plot=registered_two_factor_plot, res_col="score", facet_dims=["question", "party"])
     pi = pp.create_plot(degenerate_outer_pi_fixture, ppd, dry_run=True, escape_labels=False)
     assert pi.outer_factors == ["party"]
-    assert set(pi.outer_colors) == {"P1", "P2", "P3"}
+    assert set(pi.outer_colors) == {"party"}
+    assert set(pi.outer_colors["party"]) == {"P1", "P2", "P3"}
     # Wire invariant: the stashed split equals inner + surviving outer, so payload
     # consumers reading facet_dims/n_inner agree with cells/outer_factors.
     assert pi.facet_dims == ["party"]

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -563,6 +563,48 @@ class TestPlots:
             width=400,
         )
 
+    def test_geoplot_two_outer_dims_party_gradient(self):
+        """With a second outer dim, cells still use the colored dim's gradient (not the blue fallback)."""
+        from salk_toolkit import utils
+
+        if self.data_meta is None:
+            pytest.skip("Data metadata not available for geoplot test")
+
+        config = {
+            "res_col": "party_preference",
+            "facet_dims": ["unit", "party_preference", "gender"],
+            "internal_facet": True,
+            "plot": "geoplot",
+            "plot_args": {"separate_axes": True},
+        }
+        result = e2e_plot(config, str(self.data_file), width=400)
+        assert isinstance(result, list)
+        cells = {c.to_dict()["title"]: c.to_dict() for row in result for c in row}
+        ekre = next(v for t, v in cells.items() if "EKRE" in str(t))
+        expected = utils.gradient_from_color("#8B4513", range=[0, 1])
+        assert ekre["encoding"]["color"]["scale"]["range"] == expected
+
+    def test_geoplot_three_outer_dims_party_gradient(self):
+        """Matrix cells are fixed on every outer dim, so party gradients survive >=3 outer dims (no merge)."""
+        from salk_toolkit import utils
+
+        if self.data_meta is None:
+            pytest.skip("Data metadata not available for geoplot test")
+
+        config = {
+            "res_col": "party_preference",
+            "facet_dims": ["unit", "gender", "party_preference", "age_group"],
+            "internal_facet": True,
+            "plot": "geoplot",
+            "plot_args": {"separate_axes": True},
+        }
+        result = e2e_plot(config, str(self.data_file), width=400)
+        assert isinstance(result, list)
+        cells = {c.to_dict()["title"]: c.to_dict() for row in result for c in row}
+        ekre = next(v for t, v in cells.items() if "EKRE" in str(t))
+        expected = utils.gradient_from_color("#8B4513", range=[0, 1])
+        assert ekre["encoding"]["color"]["scale"]["range"] == expected
+
     def test_facet_dist(self, recompute):
         """Test facet distribution plot."""
         config = {


### PR DESCRIPTION
## Problem

Faceting a geoplot by a second real dimension loses the per-party gradients. Live example (modelrun 120, `party` × `state` + `gender`): every cell falls back to the blue ramp because geoplot consults only `outer_factors[0]` — after the ≥2-outer reversal that's `gender` — and pp only ever stashed the first dim's colors anyway.

Same mechanism as #63 one level up: the cell is fixed on a single `party` value that has a color, but nothing looks at it.

## Fix

- `pp/plotting.py`: `PlotInput.outer_colors` becomes per-dim — `{outer_dim: {value: color}}` for **all** outer dims, keyed by translated dim name and built after the label-translation step. The dict is **insertion-ordered by scan precedence**: observation-derived dims first (`cat_col`, the battery `question` dim), so a party gradient outranks e.g. Male/Female colors when both match. Precedence is decided in pp against *raw* names — the plot layer needs no name knowledge, so label translation can't break it.
- `plots.py` geoplot: scan `outer_colors` in order for a dim the cell is fixed on (single-valued with a color match); first hit becomes the gradient base. Legacy flat `{value: color}` dicts passed via `pparams` are shimmed to the first dim.

geoplot is the only consumer of `outer_colors` (verified by grep), so the shape change is contained.

### ≥3 outer dims

Handled by the same scan, for free: geoplot is a matrix plot (`no_faceting`), and matrix cells are sliced on the product of **all** outer dims (`plotting.py` / `payload.py`), so the `outer_factors[1:]` facet merge never applies to it — every dim is single-valued in the cell and the colored one is found regardless of position. (The merge path only runs for altair-faceted plots, which don't consume `outer_colors`.)

Exercising ≥3 dims surfaced a pre-existing crash, fixed here: unpopulated outer-dim combos produce empty cells whose min/max are NaN — geoplot's scale math then crashed (`NaN to integer` on clean main). Empty/constant cells now normalize to a `[0, 1]` relative range.

## Tests (red-first)

- `test_geoplot_two_outer_dims_party_gradient`: `party_preference` × `unit` + `gender` — asserts the exact EKRE gradient instead of the blue ramp.
- `test_geoplot_three_outer_dims_party_gradient`: `unit` + `gender` × `party_preference` × `age_group` (party deliberately not the first outer dim) — same assertion; also covers the empty-cell guard (this config crashes on clean main).
- `test_single_category_outer_factor_dropped` updated for the per-dim `outer_colors` shape.
- Existing single-outer reference test `test_geoplot_outer_colors_gradient` passes unchanged.
- Full suite: 291 passed, 1 skipped; ruff + pyright clean.

## Validating in prod

Needs the usual plots-api rollout (CI vendors stk@main at build). Then open
`https://dms.salk.ee/periskoop/explore?explore=120&obs=party&facets=state&facets=gender&plot=geoplot`
(or add Gender as Facet 2 in the rail): each party's maps should keep their party gradient per gender row instead of turning blue. Via curl, `POST /api/plots/plot-data` with `{"res_col":"party","factor_cols":["state","gender"],"plot":"geoplot","internal_facet":true}` on modelrun 120 — `cells[][].scale.stops` should end near-black for CDU-CSU (`#565656`), not blue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
