### PR TITLE
Restore read_and_process_data's data_meta as an explicit parameter

### DIFF
--- a/salk_toolkit/io/datasets.py
+++ b/salk_toolkit/io/datasets.py
@@ -396,6 +396,7 @@ def read_and_process_data(
     *,
     ignore_exclusions: bool = ...,
     add_original_inds: bool = ...,
+    data_meta: DataMeta | None = ...,
 ) -> pd.DataFrame: ...
 
 
@@ -408,6 +409,7 @@ def read_and_process_data(
     *,
     ignore_exclusions: bool = ...,
     add_original_inds: bool = ...,
+    data_meta: DataMeta | None = ...,
 ) -> tuple[pd.DataFrame, DataMeta]: ...
 
 
@@ -418,6 +420,7 @@ def read_and_process_data(
     skip_postprocessing: bool = False,
     ignore_exclusions: bool = False,
     add_original_inds: bool = False,
+    data_meta: DataMeta | None = None,
 ) -> pd.DataFrame | tuple[pd.DataFrame, DataMeta]:
     """Read and process data according to a description object.
 
@@ -428,6 +431,8 @@ def read_and_process_data(
         skip_postprocessing: Whether to skip postprocessing step.
         ignore_exclusions: Whether to keep rows listed in meta `excluded`.
         add_original_inds: Whether to keep the `original_inds` column in the result.
+        data_meta: External meta typing the columns `merge` brings in, for when this desc's own
+            meta does not describe them (a population frame merging against the survey's meta).
 
     Returns:
         DataFrame, or tuple of (DataFrame, metadata) if return_meta=True.
@@ -480,7 +485,13 @@ def read_and_process_data(
             globs["df"] = globs["df"][eval(desc_obj.filter, globs)]
         if desc_obj.merge:
             # Note: expects merge files to have corresponding meta in global DataMeta file
+            oldcols = globs["df"].columns
             globs["df"] = _perform_merges(globs["df"], desc_obj.merge, constants, meta_obj)
+            newcols = [col for col in globs["df"].columns if col not in oldcols]
+            if data_meta is not None and newcols:
+                # meta_obj describes this desc's own source; data_meta is the caller's vocabulary.
+                # Plain __setitem__, not .loc: .loc sets in place and keeps the old dtype (pandas >= 2).
+                globs["df"][newcols] = fix_df_with_meta(globs["df"][newcols].copy(), data_meta)
         if desc_obj.postprocessing and not skip_postprocessing:
             exec(_str_from_list(desc_obj.postprocessing), globs)
             globs["df"] = restore_or_assert_row_id(globs["df"], "DataDescription postprocessing")

--- a/specs/io-pipeline-refactor-design.md
+++ b/specs/io-pipeline-refactor-design.md
@@ -150,16 +150,21 @@ return `Dataset`.
   `@overload` pair on `return_meta` — the only overloads remaining, without the duplicated
   `if return_meta:` double-call.
 - `read_and_process_data(desc, return_meta=False, constants=None,
-  skip_postprocessing=False, *, ignore_exclusions=False, add_original_inds=False)`
-  — desc normalization (str / dict / `DataDescription`), inline `data` dicts,
+  skip_postprocessing=False, *, ignore_exclusions=False, add_original_inds=False,
+  data_meta=None)` — desc normalization (str / dict / `DataDescription`), inline `data` dicts,
   then loading via the same `_load_data_files` as everything else (its private
   load-concat path and its duplicate `_fix_meta_categories` pass are deleted —
   category reconciliation happens once, inside `_load_data_files`) followed by the consumption stages through `HookEnv`:
   preprocessing, `filter`, `_perform_merges` (semantics unchanged: provenance columns
   dropped on the merge side, overlap error, row-loss warning, `fix_df_with_meta` on the
   merged frame), postprocessing gated by `skip_postprocessing`. The `**kwargs` swallow is gone
-  entirely: unknown arguments are now a TypeError. (Its only caller was the ineffective
-  `file_map=` in SIP's `proxy_builder.py`, removed by salk_internal_package#95.)
+  entirely: unknown arguments are now a TypeError. The one argument that swallow carried for a
+  live caller is now explicit: `data_meta` types the columns `merge` adds, using a vocabulary the
+  desc's own meta does not have. It is not redundant with the `_perform_merges` pass — that one
+  applies `meta_obj`, this desc's *own* meta, whereas `data_meta` comes from the caller. SIP's
+  `generate_population` passes the survey meta so a population frame and the survey frame agree on
+  the categories of a column a model-level `merge` adds to both. (The `file_map=` kwarg from SIP's
+  `proxy_builder.py` was genuinely ineffective and was removed by salk_internal_package#95.)
 - `io/__init__.py` re-exports the current `__all__` plus the names other modules import
   from `salk_toolkit.io` today: `fix_df_with_meta` (dashboard), `read_json` (explorer,
   tests) and `_fix_meta_categories` (SIP `sampling/meta.py`). In-repo test imports of
@@ -175,8 +180,6 @@ Dead code, deleted rather than ported:
   any caller in STK, SIP, or tools.
 - `_process_annotated_data(raw_data=...)` and its `DataFrame | dict` / `{"F0": df}`
   compatibility branch — no callers.
-- The `kwargs["data_meta"]` post-merge fixup in `read_and_process_data` — no callers, and
-  `_perform_merges` already applies `fix_df_with_meta`.
 - The `"result_meta" in locals()` introspection in `_load_data_files`.
 - The duplicated overload towers on `_process_annotated_data` and the byte-identical
   `if return_meta:` call duplication in `read_annotated_data`.

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2364,6 +2364,40 @@ class TestReadAndProcessData:
         assert list(df["status"].cat.categories) == ["1", "2", "3"]
         assert df["status"].cat.ordered is True
 
+    def test_merge_applies_caller_supplied_data_meta(self, temp_dir):
+        """`data_meta` types merged columns this desc's own meta says nothing about.
+
+        The SIP case: a population frame merges the same file the survey does, but only the
+        survey's meta declares the merged column's categories.
+        """
+        main_csv = temp_dir / "main.csv"
+        merge_csv = temp_dir / "merge.csv"
+
+        df_to_csv(pd.DataFrame({"key": ["X", "Y"], "n": [10, 20]}), main_csv)
+        # 'B' is declared but unobserved, and the declared order is not the sorted one
+        df_to_csv(pd.DataFrame({"key": ["X", "Y"], "region_type": ["C", "A"]}), merge_csv)
+
+        desc = {"file": str(main_csv), "merge": {"file": str(merge_csv), "on": "key"}}
+        survey_meta = make_data_meta(
+            {
+                "structure": [
+                    {"name": "s", "columns": [["region_type", {"categories": ["C", "B", "A"], "ordered": True}]]}
+                ]
+            }
+        )
+
+        # Without it the column stays untyped -> a consumer inferring categories gets sorted+unordered
+        plain = read_and_process_data(desc)
+        assert plain["region_type"].dtype.name != "category"
+
+        df = read_and_process_data(desc, data_meta=survey_meta)
+        assert df["region_type"].dtype.name == "category"
+        assert list(df["region_type"].cat.categories) == ["C", "B", "A"]
+        assert df["region_type"].cat.ordered is True
+        # Values still line up with their keys, and the join key is not touched
+        assert df.set_index("key")["region_type"].to_dict() == {"X": "C", "Y": "A"}
+        assert df["key"].dtype.name != "category"
+
     def test_return_meta_extra_field_categories(self, temp_dir):
         """Extra FileDesc fields (e.g. t) should be reflected in returned meta categories."""
         # Create tiny source CSVs (no `t` column); meta declares `t` but it will be empty at this stage.


### PR DESCRIPTION
`#72` dropped the `**kwargs` swallow from `read_and_process_data` and, with it, the post-merge `data_meta` fixup. The spec justified that as *"no callers, and `_perform_merges` already applies `fix_df_with_meta`"* (`specs/io-pipeline-refactor-design.md:178`). Both halves turned out to be wrong.

## There is a caller

SIP's `generate_population` passes it (`sampling/population.py:52`), fed the survey meta that `RunStack` reads at `sampling/runner.py:283`. It's easy to miss on a grep because `data_meta=` appears ~30 times in SIP as an unrelated local.

Result on SIP `main` today: **every model with a file- or data-backed population raises `TypeError`** — 10 failures in its quick suite, including `test_main[mock]` and `test_populations[mock]`. With this branch on `PYTHONPATH`: **502 passed, 14 skipped, 0 failed**.

## `_perform_merges` is not equivalent

It applies `meta_obj` — *this desc's own* meta. For a population frame that's the census source's embedded meta, or `None` for an inline `data:` dict; it cannot know the survey's vocabulary. `data_meta` is the **caller's** meta, which is the entire point:

```python
# sampling/runner.py:270-280 — a model-level merge is folded into BOTH descs
if self.salk_model.merge:
    data_desc = data_desc.model_copy(update={"merge": [...] + list(self.salk_model.merge)})
    self.population_desc = self.population_desc.model_copy(update={"merge": [...] + list(self.salk_model.merge)})
```

Both frames gain the same columns from the same third file and have to agree on their categories. The survey read gets that for free (there `meta_obj` *is* the survey meta); the population read had only this channel.

The failure mode when it's missing is silent. Population frames are what OMs are *prepared* on (`sampling/sequence.py:113-121`), and `get_cat_input_dim_names` reads the vocabulary straight off the dtype:

```python
if df[col].dtype.name != "category":
    ccats = sorted(df[col].dropna().unique().tolist())
    is_ordered = True                      # <-- silently ordered
```

So a merged categorical arriving as plain object gives the model alphabetically sorted categories, marked ordered, missing any declared-but-unobserved level — while the survey frame has the declared ones. Same merge spec, two vocabularies, no error.

14 model descs in `sandbox/` use a model-level `merge` (`estonia/kov25`, `26-27_Riigikogu_ee`, `de_model`, …). They all happen to merge in numeric covariates today, which `fix_df_with_meta` skips — so the path is warm rather than currently misbehaving.

## Notes on the restore

- Restored as a **typed keyword**, not `**kwargs`, so #72's "unknown arguments are a `TypeError`" property is kept. Added to both `@overload`s.
- **Not a verbatim revert.** The old line assigned through `.loc[:, newcols]`, which since pandas 2 sets in place and preserves the existing dtype — on pandas 3.0.2 it was already a no-op. Uses plain `__setitem__` instead. The new test fails against the `.loc` form, which is how this surfaced.
- The join key is excluded by construction (already in `oldcols`), and non-categorical columns are untouched — both asserted.
- Corrected the spec's "Removed" list, and documented why the two fixups are not redundant.

## Gates

- STK suite: 295 passed, 1 skipped
- `pyright --project .`: 0 errors
- `ruff check` / `ruff format`: clean
- SIP quick suite against this branch: 502 passed, 14 skipped (was 10 failed / 492 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)