### PR TITLE
Type exclusivity for continuous vs categories (fixes convert_res nulling all rows, #62 regression)

### DIFF
--- a/.agents/skills/stk-data-annotations/SKILL.md
+++ b/.agents/skills/stk-data-annotations/SKILL.md
@@ -159,9 +159,12 @@ Column-level `{ meta }` should only contain fields that **differ** from the bloc
 | `continuous` | `bool` | Numeric real-valued column |
 | `datetime` | `bool` | Datetime column |
 
-`continuous` is exclusive with both `datetime` and `categories` — a column claiming to be
-both fails to load. (`datetime` + `categories: "infer"` is the one legal combination: it parses
-dates first, then buckets them into chronologically ordered `"01 Dec 25"` categories.)
+`continuous` and `categories` are exclusive — a column declaring both fails to load. A column
+that declares its own type overrides the block `scale`'s, so `scale: {"categories": [...]}` plus
+a column `{"continuous": true}` is fine: the column simply doesn't inherit the categories.
+
+`datetime` is orthogonal to both: it describes parsing, so `datetime` + `categories: "infer"`
+parses dates first and then buckets them into chronologically ordered `"01 Dec 25"` categories.
 
 **Ordering** — only meaningful for ordered categorical columns:
 
@@ -333,7 +336,7 @@ For best-worst scaling / maxdiff experiments:
 
 - `best_columns` / `worst_columns`: regex or list matching best/worst choice columns
 - `set_columns`: regex template or list for the set-membership columns
-- `setindex_column`: column containing set version index (with optional meta). Mutually exclusive with explicit set_columns data in the file.
+- `setindex_column`: column containing set version index (with optional meta; forced `continuous: true`, so it never inherits the scale's topic categories). Mutually exclusive with explicit set_columns data in the file.
 - `topics`: list of all topic strings (typically in `constants`)
 - `sets`: list of lists of 1-indexed topic indices per version (typically in `constants`)
 - Scale `translate` maps local-language topics to English

--- a/.agents/skills/stk-data-annotations/SKILL.md
+++ b/.agents/skills/stk-data-annotations/SKILL.md
@@ -159,6 +159,10 @@ Column-level `{ meta }` should only contain fields that **differ** from the bloc
 | `continuous` | `bool` | Numeric real-valued column |
 | `datetime` | `bool` | Datetime column |
 
+`continuous` is exclusive with both `datetime` and `categories` — a column claiming to be
+both fails to load. (`datetime` + `categories: "infer"` is the one legal combination: it parses
+dates first, then buckets them into chronologically ordered `"01 Dec 25"` categories.)
+
 **Ordering** — only meaningful for ordered categorical columns:
 
 | Field | Type | Purpose |

--- a/.agents/skills/stk-pp-plots/SKILL.md
+++ b/.agents/skills/stk-pp-plots/SKILL.md
@@ -98,6 +98,8 @@ For expressions polars can evaluate but `filter` can't encode, use `pl_filter` (
 
 Turn an ordered categorical response into a numeric one for plots that expect a continuous `res_col` (`boxplots`, `density`, `lines`, `violin`, ...). By default `num_values` comes from the column's annotation; override per-descriptor via `num_values` when the analytic scale needs to differ.
 
+On an already-continuous `res_col` it is a no-op cast, so it is safe to leave on. It errors on a column that is neither — a plain `datetime`, or one with no numbers to parse. The column's annotated `val_range` is preserved; an unannotated one stays unset rather than defaulting to `(0, 1)`.
+
 ```python
 {
   "plot": "boxplots",
@@ -167,6 +169,8 @@ Grid layout controls when a plot wraps multiple facets. Rarely needed — the de
 ```
 
 If you find yourself setting the same override from multiple call sites, the annotation is wrong — fix it there.
+
+The merged result is revalidated, so an override that contradicts the annotation raises. To read a categorical column as numbers use `convert_res="continuous"`, not `col_meta: {"continuous": true}`.
 
 ## When to use `return_data=True`
 

--- a/salk_toolkit/io/create_blocks.py
+++ b/salk_toolkit/io/create_blocks.py
@@ -377,11 +377,9 @@ def _create_maxdiff_metas_and_dfs(
     best_worst_col_meta = ColumnMeta(categories=effective_topics) if effective_topics is not None else ColumnMeta()
     columns_spec: dict[str, ColumnMeta] = {col: best_worst_col_meta for col in base_columns}
     if setindex_col_name is not None:
-        # The set index is the version number the respondent saw, so it is continuous - and therefore
-        # has no categories; the topic vocabulary lives on the best/worst columns that actually hold topics
-        setindex_col_meta = (setindex_col_meta or ColumnMeta()).model_copy(
-            update={"continuous": True, "categories": None}
-        )
+        # The set index is the version number the respondent saw, so it is continuous - which also keeps
+        # the block scale's topic categories off it; those belong on the best/worst columns
+        setindex_col_meta = (setindex_col_meta or ColumnMeta()).model_copy(update={"continuous": True})
         columns_spec = {setindex_col_name: setindex_col_meta} | columns_spec
 
     return [df], [

--- a/salk_toolkit/io/create_blocks.py
+++ b/salk_toolkit/io/create_blocks.py
@@ -377,13 +377,11 @@ def _create_maxdiff_metas_and_dfs(
     best_worst_col_meta = ColumnMeta(categories=effective_topics) if effective_topics is not None else ColumnMeta()
     columns_spec: dict[str, ColumnMeta] = {col: best_worst_col_meta for col in base_columns}
     if setindex_col_name is not None:
-        if setindex_col_meta is None:
-            setindex_col_meta = ColumnMeta()
-        if effective_topics is not None and setindex_col_meta.categories is None:
-            # Use translated topic names for the setindex categories
-            setindex_col_meta = setindex_col_meta.model_copy(update={"categories": effective_topics})
-        if setindex_col_meta.continuous is False:
-            setindex_col_meta = setindex_col_meta.model_copy(update={"continuous": True})
+        # The set index is the version number the respondent saw, so it is continuous - and therefore
+        # has no categories; the topic vocabulary lives on the best/worst columns that actually hold topics
+        setindex_col_meta = (setindex_col_meta or ColumnMeta()).model_copy(
+            update={"continuous": True, "categories": None}
+        )
         columns_spec = {setindex_col_name: setindex_col_meta} | columns_spec
 
     return [df], [

--- a/salk_toolkit/pp/common.py
+++ b/salk_toolkit/pp/common.py
@@ -20,11 +20,11 @@ def _question_meta_clone(
 ) -> GroupOrColumnMeta:
     """Produce a categorical copy of ``base_meta`` for the synthetic ``question`` column.
 
-    ``continuous`` and ``ordered`` are cleared so question identity is nominal, not inherited from the group.
+    Type flags and ``ordered`` are cleared so question identity is nominal, not inherited from the group.
     """
 
     clone = base_meta.model_copy(deep=True)
-    clone.continuous = False
+    clone.continuous = clone.datetime = False
     clone.ordered = False
     if categories is not None:
         clone.categories = list(categories)

--- a/salk_toolkit/pp/matching.py
+++ b/salk_toolkit/pp/matching.py
@@ -144,7 +144,7 @@ def matching_plots(
     if not cols:
         raise ValueError(f"Columns {ocols} not found in data")
 
-    if rcm.categories is not None:
+    if rcm.is_categorical:
         nonneg = True
     else:
         # Metadata-only: a data scan would cost a full pass per render; unknown counts as not non-negative
@@ -152,7 +152,7 @@ def matching_plots(
         nonneg = val_range is not None and val_range[0] is not None and val_range[0] >= 0
 
     convert_res = pp_desc.convert_res
-    if convert_res == "continuous" and (rcm.categories is not None):
+    if convert_res == "continuous" and rcm.is_categorical:
         cat_vals_seq = _get_cat_num_vals(rcm, pp_desc)
         cat_vals = [v for v in (cat_vals_seq or []) if v is not None]
         if cat_vals:
@@ -163,8 +163,8 @@ def matching_plots(
     for cn in facet_dims:
         meta = col_meta.get(cn, GroupOrColumnMeta())
         facet_metas.append({"name": cn, **meta.model_dump(mode="python")})
-    # Categorical = has categories, not marked continuous, not being converted to continuous
-    is_categorical = (rcm.categories is not None) and not rcm.continuous and convert_res != "continuous"
+    # Categorical = has categories (so neither continuous nor datetime), not being converted to continuous
+    is_categorical = rcm.is_categorical and convert_res != "continuous"
     match = {
         "draws": ("draw" in df_cols),
         "nonnegative": nonneg,
@@ -239,9 +239,8 @@ def impute_facet_dims(
     res_col = pp_desc.res_col
     convert_res = pp_desc.convert_res
     res_col_meta = col_meta[res_col]
-    has_categories = res_col_meta.categories is not None
     has_q = res_col_meta.columns is not None
-    cat_res = has_categories and convert_res != "continuous"
+    cat_res = res_col_meta.is_categorical and convert_res != "continuous"
 
     # Add res_col if we are working with a categorical input (and not converting it to continuous)
     if cat_res and res_col not in facet_dims:

--- a/salk_toolkit/pp/matching.py
+++ b/salk_toolkit/pp/matching.py
@@ -163,7 +163,6 @@ def matching_plots(
     for cn in facet_dims:
         meta = col_meta.get(cn, GroupOrColumnMeta())
         facet_metas.append({"name": cn, **meta.model_dump(mode="python")})
-    # Categorical = has categories (so neither continuous nor datetime), not being converted to continuous
     is_categorical = rcm.is_categorical and convert_res != "continuous"
     match = {
         "draws": ("draw" in df_cols),

--- a/salk_toolkit/pp/meta.py
+++ b/salk_toolkit/pp/meta.py
@@ -86,6 +86,9 @@ def _update_data_meta_with_pp_desc(
                     update = update.model_dump(mode="python", exclude_unset=True)
                 elif not isinstance(update, dict):
                     update = dict(update)
-                col_meta[key] = col_meta[key].model_copy(update=update)
+                # Revalidate: model_copy skips validators, so an override contradicting the
+                # annotation (continuous on a categorical column) would silently pass through
+                merged = col_meta[key].model_copy(update=update).model_dump(mode="python")
+                col_meta[key] = soft_validate(merged, GroupOrColumnMeta)
 
     return col_meta, gc_dict

--- a/salk_toolkit/pp/wrangle.py
+++ b/salk_toolkit/pp/wrangle.py
@@ -151,29 +151,30 @@ def pp_transform_data(
     for rc in rcl:
         res_meta = c_meta[rc]
         if pp_desc.convert_res == "continuous":
-            res_meta = _ensure_ldf_categories(c_meta, rc, filtered_df)
-            nvals = _get_cat_num_vals(res_meta, pp_desc)
+            if res_meta.datetime:
+                raise Exception(f"Cannot convert datetime column {rc} to continuous")
 
-            # Conversion only makes sense for ordered (or binary) data
-            if nvals is not None and len(nvals) > 2 and not res_meta.ordered:
-                raise Exception(
-                    f"Cannot convert {rc} to continuous because it has more than 2 values and is not ordered"
-                )
+            nvals: Sequence[float | int] = []
+            if res_meta.is_categorical:
+                res_meta = _ensure_ldf_categories(c_meta, rc, filtered_df)
+                nvals = _get_cat_num_vals(res_meta, pp_desc) or []
 
-            categories = res_meta.categories or []
-            nvals = nvals or []
-            cmap = dict(zip(categories, nvals))
-            # Categories without a numeric value (e.g. nonresponse) become null, not a failed cast.
-            # No mapping at all (already-continuous column, or no categories in meta): plain
-            # non-strict cast — replace_strict with an empty map would null every row.
-            converted = (
-                pl.col(rc).cast(pl.String).replace_strict(cmap, default=None, return_dtype=pl.Float32)
-                if cmap
-                else pl.col(rc).cast(pl.Float32, strict=False)
-            )
+                # Conversion only makes sense for ordered (or binary) data
+                if len(nvals) > 2 and not res_meta.ordered:
+                    raise Exception(
+                        f"Cannot convert {rc} to continuous because it has more than 2 values and is not ordered"
+                    )
+
+                cmap = dict(zip(res_meta.categories or [], nvals))
+                # Categories without a numeric value (e.g. nonresponse) become null, not a failed cast
+                converted = pl.col(rc).cast(pl.String).replace_strict(cmap, default=None, return_dtype=pl.Float32)
+            else:
+                # Nothing to map: the values are already the numbers, so just parse them (unparseable -> null).
+                # Via String because polars refuses to cast a categorical column straight to a number
+                converted = pl.col(rc).cast(pl.String).cast(pl.Float32, strict=False)
             filtered_df = filtered_df.with_columns(converted.fill_nan(None))
-            nvals = np.array(nvals, dtype="float")  # To handle null as nan
-            val_range = (np.nanmin(nvals), np.nanmax(nvals)) if len(nvals) > 0 else (0.0, 1.0)
+            anvals = np.array(nvals, dtype="float")  # To handle null as nan
+            val_range = (np.nanmin(anvals), np.nanmax(anvals)) if len(nvals) > 0 else (res_meta.val_range or (0.0, 1.0))
             update_payload: Dict[str, Any] = {
                 "continuous": True,
                 "categories": None,

--- a/salk_toolkit/pp/wrangle.py
+++ b/salk_toolkit/pp/wrangle.py
@@ -163,10 +163,15 @@ def pp_transform_data(
             categories = res_meta.categories or []
             nvals = nvals or []
             cmap = dict(zip(categories, nvals))
-            # Categories without a numeric value (e.g. nonresponse) become null, not a failed cast
-            filtered_df = filtered_df.with_columns(
-                pl.col(rc).cast(pl.String).replace_strict(cmap, default=None, return_dtype=pl.Float32).fill_nan(None)
+            # Categories without a numeric value (e.g. nonresponse) become null, not a failed cast.
+            # No mapping at all (already-continuous column, or no categories in meta): plain
+            # non-strict cast — replace_strict with an empty map would null every row.
+            converted = (
+                pl.col(rc).cast(pl.String).replace_strict(cmap, default=None, return_dtype=pl.Float32)
+                if cmap
+                else pl.col(rc).cast(pl.Float32, strict=False)
             )
+            filtered_df = filtered_df.with_columns(converted.fill_nan(None))
             nvals = np.array(nvals, dtype="float")  # To handle null as nan
             val_range = (np.nanmin(nvals), np.nanmax(nvals)) if len(nvals) > 0 else (0.0, 1.0)
             update_payload: Dict[str, Any] = {

--- a/salk_toolkit/pp/wrangle.py
+++ b/salk_toolkit/pp/wrangle.py
@@ -154,7 +154,7 @@ def pp_transform_data(
             nvals: Sequence[float | int] = []
             if res_meta.is_categorical:
                 res_meta = _ensure_ldf_categories(c_meta, rc, filtered_df)
-                nvals = _get_cat_num_vals(res_meta, pp_desc) or []
+                nvals = _get_cat_num_vals(res_meta, pp_desc)
 
                 # Conversion only makes sense for ordered (or binary) data
                 if len(nvals) > 2 and not res_meta.ordered:
@@ -167,16 +167,21 @@ def pp_transform_data(
                 converted = pl.col(rc).cast(pl.String).replace_strict(cmap, default=None, return_dtype=pl.Float32)
             elif res_meta.datetime:
                 raise Exception(f"Cannot convert datetime column {rc} to continuous")
+            elif res_meta.continuous or schema[rc].is_numeric():
+                # Already numbers: just parse them (unparseable -> null). Only non-numeric dtypes need the
+                # String hop - polars refuses to cast a categorical straight to a number, and on a numeric
+                # column the detour stringifies every value for nothing
+                col = pl.col(rc) if schema[rc].is_numeric() else pl.col(rc).cast(pl.String)
+                converted = col.cast(pl.Float64, strict=False)
             else:
-                # Nothing to map: the values are already the numbers, so just parse them (unparseable -> null).
-                # Via String because polars refuses to cast a categorical column straight to a number
-                converted = pl.col(rc).cast(pl.String).cast(pl.Float32, strict=False)
+                raise Exception(f"Cannot convert {rc} to continuous: it is neither categorical nor continuous")
             filtered_df = filtered_df.with_columns(converted.fill_nan(None))
             anvals = np.array(nvals, dtype="float")  # To handle null as nan
-            val_range = (np.nanmin(anvals), np.nanmax(anvals)) if len(nvals) > 0 else (res_meta.val_range or (0.0, 1.0))
+            val_range = (np.nanmin(anvals), np.nanmax(anvals)) if len(nvals) > 0 else res_meta.val_range
             update_payload: Dict[str, Any] = {
                 "continuous": True,
                 "categories": None,
+                "datetime": False,  # The converted column holds numbers, whatever it was parsed from
                 "ordered": False,
                 "groups": {},
                 "colors": {},

--- a/salk_toolkit/pp/wrangle.py
+++ b/salk_toolkit/pp/wrangle.py
@@ -151,9 +151,6 @@ def pp_transform_data(
     for rc in rcl:
         res_meta = c_meta[rc]
         if pp_desc.convert_res == "continuous":
-            if res_meta.datetime:
-                raise Exception(f"Cannot convert datetime column {rc} to continuous")
-
             nvals: Sequence[float | int] = []
             if res_meta.is_categorical:
                 res_meta = _ensure_ldf_categories(c_meta, rc, filtered_df)
@@ -168,6 +165,8 @@ def pp_transform_data(
                 cmap = dict(zip(res_meta.categories or [], nvals))
                 # Categories without a numeric value (e.g. nonresponse) become null, not a failed cast
                 converted = pl.col(rc).cast(pl.String).replace_strict(cmap, default=None, return_dtype=pl.Float32)
+            elif res_meta.datetime:
+                raise Exception(f"Cannot convert datetime column {rc} to continuous")
             else:
                 # Nothing to map: the values are already the numbers, so just parse them (unparseable -> null).
                 # Via String because polars refuses to cast a categorical column straight to a number

--- a/salk_toolkit/tools/explorer.py
+++ b/salk_toolkit/tools/explorer.py
@@ -279,7 +279,7 @@ with st.sidebar:  # .expander("Select dimensions"):
     args["res_col"] = obs_name
 
     res_meta = c_meta[args["res_col"]]
-    res_cont = (not res_meta.categories) or args.get("convert_res") == "continuous"
+    res_cont = (not res_meta.is_categorical) or args.get("convert_res") == "continuous"
 
     modifiers = c_meta[obs_name].modifiers
     all_dims = list(modifiers) + all_dims

--- a/salk_toolkit/validation.py
+++ b/salk_toolkit/validation.py
@@ -182,6 +182,11 @@ class ColumnMeta(PBase):
     mandates: Optional[MandatesDict] = None  # Mandate count mapping for the electoral system
     col_prefix: Optional[str] = None  # Prefix prepended to column names in data (from scale block)
 
+    @property
+    def is_categorical(self) -> bool:
+        """Categories only describe categorical columns - they mean nothing on continuous/datetime ones."""
+        return self.categories is not None and not self.continuous and not self.datetime
+
     @model_serializer(mode="wrap")
     def _serialize_model(
         self, handler: Callable[[BaseModel], dict[str, Any]], info: SerializationInfo

--- a/salk_toolkit/validation.py
+++ b/salk_toolkit/validation.py
@@ -184,8 +184,8 @@ class ColumnMeta(PBase):
 
     @property
     def is_categorical(self) -> bool:
-        """Categories only describe categorical columns - they mean nothing on continuous/datetime ones."""
-        return self.categories is not None and not self.continuous and not self.datetime
+        """Categories describe categorical columns only - a continuous column never has them (see check_categorical)."""
+        return self.categories is not None and not self.continuous
 
     @model_serializer(mode="wrap")
     def _serialize_model(
@@ -198,6 +198,13 @@ class ColumnMeta(PBase):
 
     @model_validator(mode="after")
     def check_categorical(self, info: ValidationInfo) -> Self:
+        # Type flags are exclusive, and this is never soft: a continuous column that also carries
+        # categories is pure confusion, so fail the load rather than pick a winner
+        if self.continuous and self.datetime:
+            raise ValueError("Column cannot be both continuous and datetime")
+        if self.continuous and self.categories is not None:
+            raise ValueError("Column is continuous, so it cannot have categories")
+
         if info.context and info.context.get("validation_mode") == "soft":
             return self
         if self.categories is None:

--- a/salk_toolkit/validation.py
+++ b/salk_toolkit/validation.py
@@ -184,7 +184,7 @@ class ColumnMeta(PBase):
 
     @property
     def is_categorical(self) -> bool:
-        """Categories describe categorical columns only - a continuous column never has them (see check_categorical)."""
+        """Has categories to work with. `datetime` is orthogonal: parsed dates can be bucketed into categories."""
         return self.categories is not None and not self.continuous
 
     @model_serializer(mode="wrap")
@@ -198,12 +198,11 @@ class ColumnMeta(PBase):
 
     @model_validator(mode="after")
     def check_categorical(self, info: ValidationInfo) -> Self:
-        # Type flags are exclusive, and this is never soft: a continuous column that also carries
-        # categories is pure confusion, so fail the load rather than pick a winner
-        if self.continuous and self.datetime:
-            raise ValueError("Column cannot be both continuous and datetime")
+        # Continuous and categorical are exclusive, and this is never soft: a column claiming both is
+        # pure confusion, so fail the load rather than pick a winner. (datetime is orthogonal - it
+        # describes parsing, and the parsed values can be bucketed into categories.)
         if self.continuous and self.categories is not None:
-            raise ValueError("Column is continuous, so it cannot have categories")
+            raise ValueError(f"Column is continuous, so it cannot have categories: {self.categories}")
 
         if info.context and info.context.get("validation_mode") == "soft":
             return self
@@ -299,7 +298,13 @@ class ColumnBlockMeta(PBase):
         # Merge scale with each column's metadata
         merged_columns: dict[str, ColumnMeta] = {}
         for col_name, col_meta in self.columns.items():
-            merged_meta = merge_pydantic_models(self.scale, col_meta, context=info.context)
+            # A column declaring its own type overrides the block's, so drop the counterpart it would inherit
+            scale = self.scale
+            if col_meta.continuous and scale.categories is not None:
+                scale = scale.model_copy(update={"categories": None})
+            elif col_meta.categories is not None and scale.continuous:
+                scale = scale.model_copy(update={"continuous": False})
+            merged_meta = merge_pydantic_models(scale, col_meta, context=info.context)
 
             # Special case: Don't inherit label from scale unless explicitly set on column
             # This prevents scale-level labels from propagating to individual columns

--- a/specs/2026-08-05-#79-continuous-categories-exclusive.md
+++ b/specs/2026-08-05-#79-continuous-categories-exclusive.md
@@ -1,0 +1,80 @@
+# Continuous and categorical are exclusive column types (PR #79)
+
+**Modules:** `salk_toolkit/validation.py`, `salk_toolkit/pp/` (`wrangle.py`, `meta.py`,
+`matching.py`, `common.py`), `salk_toolkit/io/create_blocks.py`, `salk_toolkit/tools/explorer.py`,
+`.agents/skills/stk-data-annotations/`, `.agents/skills/stk-pp-plots/`
+
+## Goal
+
+A column is either continuous or categorical, and the annotation says which. Previously nothing
+enforced that, so `continuous: true` alongside `categories` was constructible and each consumer
+guessed differently — `matching_plots` checked `not continuous`, `impute_facet_dims` didn't, and
+`pp_transform_data` built a category→number map for a column that had no meaningful categories.
+Since #62 that last one nulled every row (`replace_strict({}, default=None)` over an empty map),
+so `convert_res: continuous` on a natively-continuous response returned an empty grid.
+
+## Design
+
+**The invariant.** `ColumnMeta.check_categorical` raises when `continuous` is set together with
+`categories`. Unlike the rest of that validator it runs *before* the soft-mode early return: every
+io load path calls `soft_validate`, so a soft-only check would never fire on a real load. `datetime`
+is orthogonal to both — it describes parsing, and parsed dates get bucketed into ordered
+`"01 Dec 25"` categories, so a datetime column may legitimately be categorical.
+
+**Scale inheritance is where the contradiction actually comes from.** No one writes both flags on
+one column; they write `{"continuous": true}` on a column inside a block whose `scale` carries
+`categories`, and `merge_scale_with_columns` merges the two. A column declaring its own type now
+overrides the block's: the scale copy handed to `merge_pydantic_models` gets the counterpart
+cleared (`categories` dropped for a continuous column, `continuous` for a categorical one). The
+error is left for the case it was written for — both asserted at the same level.
+
+**One predicate.** `ColumnMeta.is_categorical` (`categories is not None and not continuous`)
+replaces five open-coded variants across `matching.py` (`nonneg`, the `convert_res` value scan,
+`is_categorical`, `impute_facet_dims`) and `explorer.py`.
+
+**`convert_res: "continuous"` dispatches on the column type** rather than on whether a map came
+out non-empty:
+
+- categorical → build `cmap` from `categories` × `num_values` and `replace_strict` (unchanged #62
+  semantics: a category with no numeric value becomes null, not a failed cast);
+- plain `datetime` → error;
+- `continuous`, or any numeric dtype → parse the values (`Float64`, `strict=False`);
+- anything else → error, rather than casting the column to all-null.
+
+The resulting meta declares `continuous: True`, clears `categories`/`ordered`/`num_values`, and
+also clears `datetime` — whatever it was parsed from, the converted column holds numbers.
+
+**Descriptor overrides are revalidated.** `pp_desc.col_meta` was applied with
+`model_copy(update=...)`, which skips validators, so an override could reconstruct the forbidden
+state at plot time and silently empty the frame. The merged result now goes back through
+`soft_validate`, so a contradicting override raises naming the offending categories. Reading a
+categorical column as numbers is `convert_res`, not `col_meta: {"continuous": true}`.
+
+**MaxDiff set index.** The generated block copies its source scale wholesale, which for maxdiff
+carries the topic list. The set-index column holds the version number the respondent saw, so
+`_create_maxdiff_metas_and_dfs` forces `continuous: True` on it — which under the merge rule is
+enough to keep the topics off it. Topic vocabulary lives on the best/worst columns that contain
+topics.
+
+## Implementation notes
+
+- The check must fire in soft mode, and the merge rule must run *before* `merge_pydantic_models`,
+  not after: the merged model is validated on construction, so a post-hoc cleanup never gets to run.
+- "No categories" is not expressible in a serialized column meta: `categories: null` equals the
+  field default and `serialize_pbase` prunes defaults. An explicit `None` therefore cannot cancel
+  an inherited scale value across a write/read round-trip — which is why the rule lives in the
+  merge and not in what generators write.
+- polars refuses to cast a Categorical column straight to a number, so non-numeric dtypes take a
+  `cast(pl.String)` hop first. Numeric dtypes skip it: the detour stringifies every value for
+  nothing and costs ~45% of `pp_transform_data` (87 → 25 ms per million rows). The mapped path
+  stays `Float32` (small category codes); the parsed path is `Float64`, since those values are the
+  data itself and `Float32` silently rounds anything past ~7 significant digits.
+- An unannotated `val_range` stays `None` after conversion instead of being fabricated as
+  `(0, 1)` — that default only ever made sense for the always-mapped path.
+- `_question_meta_clone` clears `datetime` alongside `continuous`: the synthetic `question` column
+  holds column names and is nominal regardless of what its group contained.
+- Corpus effect, measured across 1250 parquet-embedded metas and every annotation JSON under
+  `~/salk`: one genuine violation (lt `Q2status`, a 5-point living-standard rating annotated
+  `continuous` + `categories: "infer"`; corrected to `ordered` categorical in the annotation and in
+  the three stored artifacts carrying the old meta). Net load regressions against the previous
+  `main`: zero.

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1293,18 +1293,42 @@ class TestCategoricalFeatures:
         assert df["dt"].dtype.name == "category"
         assert list(df["dt"].dtype.categories) == ["01 Jan 25", "01 Dec 25", "02 Dec 25"]
 
-    @pytest.mark.parametrize(
-        "col_meta", [{"continuous": True, "categories": "infer"}, {"continuous": True, "categories": [1, 2, 3]}]
-    )
-    def test_continuous_column_with_categories_fails_to_load(self, csv_file, meta_file, col_meta):
+    @pytest.mark.parametrize("categories", ["infer", [1, 2, 3]], ids=["infer", "explicit"])
+    def test_continuous_column_with_categories_fails_to_load(self, csv_file, meta_file, categories):
         """Continuous and categorical are exclusive: a column claiming both is rejected, not silently resolved."""
         df_to_csv(pd.DataFrame({"score": [1, 2, 3], "id": [1, 2, 3]}), csv_file)
+        col_meta = {"continuous": True, "categories": categories}
         write_json(
             meta_file, {"file": "test.csv", "structure": [{"name": "test", "columns": ["id", ["score", col_meta]]}]}
         )
 
         with pytest.raises(ValidationError, match="continuous, so it cannot have categories"):
             read_annotated_data(str(meta_file))
+
+    def test_column_type_overrides_block_scale_type(self, csv_file, meta_file):
+        """A column declaring `continuous` opts out of the block's categories instead of inheriting a contradiction."""
+        df_to_csv(pd.DataFrame({"score": [1, 2, 3], "rating": ["a", "b", "a"], "id": [1, 2, 3]}), csv_file)
+        write_json(
+            meta_file,
+            {
+                "file": "test.csv",
+                "structure": [
+                    {"name": "sys", "columns": ["id"]},
+                    {
+                        "name": "block",
+                        "scale": {"categories": ["a", "b"]},
+                        "columns": [["rating", {}], ["score", {"continuous": True}]],
+                    },
+                ],
+            },
+        )
+
+        df, dmeta = read_and_process_data(str(meta_file), return_meta=True)
+
+        cmeta = extract_column_meta(dmeta)
+        assert (cmeta["score"].continuous, cmeta["score"].categories) == (True, None)
+        assert cmeta["rating"].categories == ["a", "b"]
+        assert df["score"].tolist() == [1, 2, 3]
 
     def test_numeric_to_categorical_nearest_mapping(self, csv_file, meta_file):
         """Test numeric series mapping to nearest categorical values"""

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -399,7 +399,6 @@ class TestReadAnnotatedData:
         expected_structure: dict[str, ColumnBlockMeta],
         data_df: pd.DataFrame | None = None,
         check_q2_version: bool = False,
-        expected_topics: list[str] | None = None,
     ) -> None:
         """Helper to compare actual and expected structures."""
         # System blocks like 'files' are automatically added by read_and_process_data
@@ -436,10 +435,10 @@ class TestReadAnnotatedData:
                     assert q2_version_meta.continuous, (
                         f"Q2_Version should be continuous, got continuous={q2_version_meta.continuous}"
                     )
-                    if expected_topics:
-                        assert q2_version_meta.categories == expected_topics, (
-                            f"Q2_Version should inherit scale categories, got {q2_version_meta.categories}"
-                        )
+                    # It is the version number, not a topic: continuous columns never carry categories
+                    assert q2_version_meta.categories is None, (
+                        f"Q2_Version is continuous, so it should have no categories, got {q2_version_meta.categories}"
+                    )
                     column_list = list(actual_block.columns.keys())
                     assert column_list[0] == "Q2_Version", (
                         f"Q2_Version should be first column, but got order: {column_list[:5]}"
@@ -558,7 +557,7 @@ class TestReadAnnotatedData:
             topics=topics.tolist(),
             column_names=columnorder,
             setindex_column="Q2_Version",
-            setindex_meta=ColumnMeta(continuous=True, categories=topics.tolist()),
+            setindex_meta=ColumnMeta(continuous=True),
         )
 
         df = df[["Q2_Version"] + sorted(columnorder)]
@@ -579,7 +578,6 @@ class TestReadAnnotatedData:
             expected_structure,
             data_df=data_df,
             check_q2_version=True,
-            expected_topics=topics.tolist(),
         )
 
     def test_maxdiff_create_block_explicit_sets(self, meta_file, csv_file):
@@ -1294,6 +1292,19 @@ class TestCategoricalFeatures:
 
         assert df["dt"].dtype.name == "category"
         assert list(df["dt"].dtype.categories) == ["01 Jan 25", "01 Dec 25", "02 Dec 25"]
+
+    @pytest.mark.parametrize(
+        "col_meta", [{"continuous": True, "categories": "infer"}, {"continuous": True, "categories": [1, 2, 3]}]
+    )
+    def test_continuous_column_with_categories_fails_to_load(self, csv_file, meta_file, col_meta):
+        """Continuous and categorical are exclusive: a column claiming both is rejected, not silently resolved."""
+        df_to_csv(pd.DataFrame({"score": [1, 2, 3], "id": [1, 2, 3]}), csv_file)
+        write_json(
+            meta_file, {"file": "test.csv", "structure": [{"name": "test", "columns": ["id", ["score", col_meta]]}]}
+        )
+
+        with pytest.raises(ValidationError, match="continuous, so it cannot have categories"):
+            read_annotated_data(str(meta_file))
 
     def test_numeric_to_categorical_nearest_mapping(self, csv_file, meta_file):
         """Test numeric series mapping to nearest categorical values"""

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -27,7 +27,9 @@ from salk_toolkit.pp import (
     stk_plot,
     _update_data_meta_with_pp_desc,
 )
+from salk_toolkit.pp.common import _question_meta_clone
 from salk_toolkit.validation import DataMeta, GroupOrColumnMeta, PlotDescriptor, soft_validate
+from pydantic import ValidationError
 
 
 def make_data_meta(meta_dict: dict[str, object]) -> DataMeta:
@@ -413,22 +415,40 @@ def test_convert_res_continuous_on_continuous_col_keeps_values(values: Any) -> N
     assert by_gender["Male"] == pytest.approx(6.0)
 
 
-def test_convert_res_continuous_keeps_declared_val_range() -> None:
-    """A continuous column's declared val_range survives convert_res - it must not collapse to (0, 1)."""
+def test_convert_res_continuous_keeps_full_precision() -> None:
+    """Values are the data itself here, not category codes, so they must not be rounded to Float32."""
+    df = pd.DataFrame({"draw": [0] * 2, "gender": ["Female", "Male"], "vote_prob": [16777217.0, 1234567891.0]})
+    ppd = soft_validate(
+        {"res_col": "vote_prob", "factor_cols": ["gender"], "convert_res": "continuous", "plot": "boxplots"},
+        PlotDescriptor,
+    )
+
+    pi = pp_transform_data(pl.LazyFrame(df), _continuous_res_meta({"continuous": True}), ppd)
+
+    by_gender = dict(zip(pi.data["gender"], pd.to_numeric(pi.data[pi.value_col], errors="raise")))
+    assert by_gender["Female"] == 16777217.0
+
+
+@pytest.mark.parametrize(
+    "col_meta,expected",
+    [({"continuous": True, "val_range": [0.0, 10.0]}, (0.0, 10.0)), ({"continuous": True}, None)],
+    ids=["declared", "undeclared"],
+)
+def test_convert_res_continuous_reports_declared_val_range(col_meta: dict[str, Any], expected: Any) -> None:
+    """A declared val_range survives convert_res; an undeclared one stays unknown rather than becoming (0, 1)."""
     df = pd.DataFrame({"draw": [0] * 4, "gender": ["Female", "Male"] * 2, "vote_prob": [2.0, 4.0, 6.0, 8.0]})
     ppd = soft_validate(
         {"res_col": "vote_prob", "factor_cols": ["gender"], "convert_res": "continuous", "plot": "boxplots"},
         PlotDescriptor,
     )
 
-    data_meta = _continuous_res_meta({"continuous": True, "val_range": [0.0, 10.0]})
-    pi = pp_transform_data(pl.LazyFrame(df), data_meta, ppd)
+    pi = pp_transform_data(pl.LazyFrame(df), _continuous_res_meta(col_meta), ppd)
 
-    assert pi.val_range == (0.0, 10.0)
+    assert pi.val_range == expected
 
 
 def test_convert_res_continuous_rejects_datetime() -> None:
-    """convert_res on a datetime column is not a thing - fail loudly instead of casting timestamps to floats."""
+    """convert_res on a plain datetime column is not a thing - fail loudly instead of casting timestamps to floats."""
     df = pd.DataFrame({"draw": [0] * 2, "gender": ["Female", "Male"], "when": pd.to_datetime(["2026-01-01"] * 2)})
     ppd = soft_validate(
         {"res_col": "when", "factor_cols": ["gender"], "convert_res": "continuous", "plot": "boxplots"},
@@ -439,14 +459,57 @@ def test_convert_res_continuous_rejects_datetime() -> None:
         pp_transform_data(pl.LazyFrame(df), _continuous_res_meta({"datetime": True}, col="when"), ppd)
 
 
-def test_continuous_res_col_is_not_faceted_by_itself() -> None:
-    """A continuous response column is not a set of categories, so it never becomes a facet dimension."""
-    ppd = soft_validate({"res_col": "score", "facet_dims": ["gender"], "plot": "boxplots"}, PlotDescriptor)
-    col_meta_map, _ = _update_data_meta_with_pp_desc(_continuous_res_meta({"continuous": True}, col="score"), ppd)
+def test_convert_res_continuous_on_bucketed_datetime_maps_categories() -> None:
+    """datetime is orthogonal to categorical: a parse-then-bucket column still converts through its categories."""
+    df = pd.DataFrame(
+        {
+            "draw": [0] * 4,
+            "gender": ["Female", "Male"] * 2,
+            "when": pd.Categorical(["01 Jan 25", "02 Jan 25"] * 2, categories=["01 Jan 25", "02 Jan 25"], ordered=True),
+        }
+    )
+    col_meta = {"datetime": True, "categories": ["01 Jan 25", "02 Jan 25"], "ordered": True, "num_values": [1.0, 2.0]}
+    ppd = soft_validate(
+        {"res_col": "when", "factor_cols": ["gender"], "convert_res": "continuous", "plot": "boxplots"},
+        PlotDescriptor,
+    )
 
-    facet_dims = impute_facet_dims(ppd, col_meta_map)
+    pi = pp_transform_data(pl.LazyFrame(df), _continuous_res_meta(col_meta, col="when"), ppd)
 
-    assert "score" not in facet_dims
+    by_gender = dict(zip(pi.data["gender"], pd.to_numeric(pi.data[pi.value_col], errors="raise")))
+    assert by_gender["Female"] == pytest.approx(1.0)
+    assert by_gender["Male"] == pytest.approx(2.0)
+
+
+def test_convert_res_continuous_rejects_uninterpretable_column() -> None:
+    """Neither categories to map nor numbers to parse: error instead of casting the whole column to null."""
+    df = pd.DataFrame({"draw": [0] * 2, "gender": ["Female", "Male"], "note": ["yes", "no"]})
+    ppd = soft_validate(
+        {"res_col": "note", "factor_cols": ["gender"], "convert_res": "continuous", "plot": "boxplots"},
+        PlotDescriptor,
+    )
+
+    with pytest.raises(Exception, match="neither categorical nor continuous"):
+        pp_transform_data(pl.LazyFrame(df), _continuous_res_meta({}, col="note"), ppd)
+
+
+def test_col_meta_override_contradicting_the_annotation_raises() -> None:
+    """Descriptor overrides bypass model validation, so the merged result is revalidated - loudly."""
+    data_meta = _continuous_res_meta({"categories": ["low", "high"], "ordered": True}, col="q")
+    ppd = soft_validate({"res_col": "q", "plot": "boxplots", "col_meta": {"q": {"continuous": True}}}, PlotDescriptor)
+
+    with pytest.raises(ValidationError, match="continuous, so it cannot have categories"):
+        _update_data_meta_with_pp_desc(data_meta, ppd)
+
+
+def test_question_meta_clone_is_nominal() -> None:
+    """The synthetic `question` column holds column names, so it inherits no type flag from its group."""
+    base = soft_validate({"datetime": True, "categories": ["01 Jan 25"], "val_range": None}, GroupOrColumnMeta)
+
+    clone = _question_meta_clone(base, ["q1", "q2"])
+
+    assert (clone.datetime, clone.continuous, clone.ordered) == (False, False, False)
+    assert clone.categories == ["q1", "q2"]
 
 
 def test_get_plot_fn_builds_chart_from_plot_input() -> None:

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -373,47 +373,86 @@ def test_convert_res_continuous_maps_unmapped_nonresponse_to_null() -> None:
     assert by_gender["Male"] == pytest.approx((-1 + 1 + 1 + 2 + 2) / 5)
 
 
-def test_convert_res_continuous_on_native_continuous_keeps_values() -> None:
-    """convert_res on an already-continuous column (no categories → empty cmap) must not null the data."""
-    data_meta = make_data_meta(
+def _continuous_res_meta(col_meta: dict[str, Any], col: str = "vote_prob") -> DataMeta:
+    """A gender + one-response-column data meta, response column meta given by the caller."""
+    return make_data_meta(
         {
             "structure": [
-                {
-                    "name": "demographics",
-                    "scale": {},
-                    "columns": [["gender", {"categories": ["Female", "Male"]}]],
-                },
-                {
-                    "name": "probs",
-                    "scale": {},
-                    "columns": [["vote_prob", {"continuous": True}]],
-                },
+                {"name": "demographics", "scale": {}, "columns": [["gender", {"categories": ["Female", "Male"]}]]},
+                {"name": "probs", "scale": {}, "columns": [[col, col_meta]]},
             ]
         }
     )
+
+
+@pytest.mark.parametrize(
+    "col_meta,values",
+    [
+        ({"continuous": True}, [2.0, 4.0, 6.0, 8.0]),  # No categories at all
+        ({"continuous": True, "categories": "infer"}, [2.0, 4.0, 6.0, 8.0]),  # Categories inferred off the numbers
+        ({"continuous": True, "categories": [2.0, 4.0, 6.0, 8.0], "ordered": True}, [2.0, 4.0, 6.0, 8.0]),
+        # 'infer' on a continuous column also makes io store the values as a string categorical
+        ({"continuous": True, "categories": "infer"}, pd.Categorical(["2", "4", "6", "8"])),
+    ],
+    ids=["no-categories", "infer", "explicit-categories", "infer-stored-as-categorical"],
+)
+def test_convert_res_continuous_ignores_categories_on_continuous_col(col_meta: dict[str, Any], values: Any) -> None:
+    """Categories mean nothing on a continuous column: convert_res must cast, never map (and never null the data)."""
     df = pd.DataFrame(
         {
             "draw": [0] * 4,
             "gender": ["Female", "Male", "Female", "Male"],
-            "vote_prob": [2.0, 4.0, 6.0, 8.0],
+            "vote_prob": values,
         }
     )
     ppd = soft_validate(
-        {
-            "res_col": "vote_prob",
-            "factor_cols": ["gender"],
-            "convert_res": "continuous",
-            "plot": "boxplots",
-        },
+        {"res_col": "vote_prob", "factor_cols": ["gender"], "convert_res": "continuous", "plot": "boxplots"},
         PlotDescriptor,
     )
 
-    pi = pp_transform_data(pl.LazyFrame(df), data_meta, ppd)
+    pi = pp_transform_data(pl.LazyFrame(df), _continuous_res_meta(col_meta), ppd)
 
     assert len(pi.data) > 0
     by_gender = dict(zip(pi.data["gender"], pd.to_numeric(pi.data[pi.value_col], errors="raise")))
     assert by_gender["Female"] == pytest.approx(4.0)
     assert by_gender["Male"] == pytest.approx(6.0)
+
+
+def test_convert_res_continuous_keeps_declared_val_range() -> None:
+    """A continuous column's declared val_range survives convert_res - it must not collapse to (0, 1)."""
+    df = pd.DataFrame({"draw": [0] * 4, "gender": ["Female", "Male"] * 2, "vote_prob": [2.0, 4.0, 6.0, 8.0]})
+    ppd = soft_validate(
+        {"res_col": "vote_prob", "factor_cols": ["gender"], "convert_res": "continuous", "plot": "boxplots"},
+        PlotDescriptor,
+    )
+
+    data_meta = _continuous_res_meta({"continuous": True, "val_range": [0.0, 10.0]})
+    pi = pp_transform_data(pl.LazyFrame(df), data_meta, ppd)
+
+    assert pi.val_range == (0.0, 10.0)
+
+
+def test_convert_res_continuous_rejects_datetime() -> None:
+    """convert_res on a datetime column is not a thing - fail loudly instead of casting timestamps to floats."""
+    df = pd.DataFrame({"draw": [0] * 2, "gender": ["Female", "Male"], "when": pd.to_datetime(["2026-01-01"] * 2)})
+    ppd = soft_validate(
+        {"res_col": "when", "factor_cols": ["gender"], "convert_res": "continuous", "plot": "boxplots"},
+        PlotDescriptor,
+    )
+
+    with pytest.raises(Exception, match="Cannot convert datetime column when"):
+        pp_transform_data(pl.LazyFrame(df), _continuous_res_meta({"datetime": True}, col="when"), ppd)
+
+
+@pytest.mark.parametrize("col_meta", [{"continuous": True, "categories": "infer"}, {"datetime": True}])
+def test_non_categorical_res_col_is_not_faceted_by_itself(col_meta: dict[str, Any]) -> None:
+    """Continuous/datetime response columns are not categories, so they never become a facet dimension."""
+    ppd = soft_validate({"res_col": "score", "facet_dims": ["gender"], "plot": "boxplots"}, PlotDescriptor)
+    col_meta_map, _ = _update_data_meta_with_pp_desc(_continuous_res_meta(col_meta, col="score"), ppd)
+
+    facet_dims = impute_facet_dims(ppd, col_meta_map)
+
+    assert "score" not in facet_dims
 
 
 def test_get_plot_fn_builds_chart_from_plot_input() -> None:

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -386,18 +386,13 @@ def _continuous_res_meta(col_meta: dict[str, Any], col: str = "vote_prob") -> Da
 
 
 @pytest.mark.parametrize(
-    "col_meta,values",
-    [
-        ({"continuous": True}, [2.0, 4.0, 6.0, 8.0]),  # No categories at all
-        ({"continuous": True, "categories": "infer"}, [2.0, 4.0, 6.0, 8.0]),  # Categories inferred off the numbers
-        ({"continuous": True, "categories": [2.0, 4.0, 6.0, 8.0], "ordered": True}, [2.0, 4.0, 6.0, 8.0]),
-        # 'infer' on a continuous column also makes io store the values as a string categorical
-        ({"continuous": True, "categories": "infer"}, pd.Categorical(["2", "4", "6", "8"])),
-    ],
-    ids=["no-categories", "infer", "explicit-categories", "infer-stored-as-categorical"],
+    "values",
+    [[2.0, 4.0, 6.0, 8.0], pd.Categorical(["2", "4", "6", "8"])],
+    ids=["float-column", "stored-as-categorical"],
 )
-def test_convert_res_continuous_ignores_categories_on_continuous_col(col_meta: dict[str, Any], values: Any) -> None:
-    """Categories mean nothing on a continuous column: convert_res must cast, never map (and never null the data)."""
+def test_convert_res_continuous_on_continuous_col_keeps_values(values: Any) -> None:
+    """A continuous column has no categories to map, so convert_res must cast - never null the whole frame."""
+    col_meta = {"continuous": True}
     df = pd.DataFrame(
         {
             "draw": [0] * 4,
@@ -444,11 +439,10 @@ def test_convert_res_continuous_rejects_datetime() -> None:
         pp_transform_data(pl.LazyFrame(df), _continuous_res_meta({"datetime": True}, col="when"), ppd)
 
 
-@pytest.mark.parametrize("col_meta", [{"continuous": True, "categories": "infer"}, {"datetime": True}])
-def test_non_categorical_res_col_is_not_faceted_by_itself(col_meta: dict[str, Any]) -> None:
-    """Continuous/datetime response columns are not categories, so they never become a facet dimension."""
+def test_continuous_res_col_is_not_faceted_by_itself() -> None:
+    """A continuous response column is not a set of categories, so it never becomes a facet dimension."""
     ppd = soft_validate({"res_col": "score", "facet_dims": ["gender"], "plot": "boxplots"}, PlotDescriptor)
-    col_meta_map, _ = _update_data_meta_with_pp_desc(_continuous_res_meta(col_meta, col="score"), ppd)
+    col_meta_map, _ = _update_data_meta_with_pp_desc(_continuous_res_meta({"continuous": True}, col="score"), ppd)
 
     facet_dims = impute_facet_dims(ppd, col_meta_map)
 

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -373,6 +373,49 @@ def test_convert_res_continuous_maps_unmapped_nonresponse_to_null() -> None:
     assert by_gender["Male"] == pytest.approx((-1 + 1 + 1 + 2 + 2) / 5)
 
 
+def test_convert_res_continuous_on_native_continuous_keeps_values() -> None:
+    """convert_res on an already-continuous column (no categories → empty cmap) must not null the data."""
+    data_meta = make_data_meta(
+        {
+            "structure": [
+                {
+                    "name": "demographics",
+                    "scale": {},
+                    "columns": [["gender", {"categories": ["Female", "Male"]}]],
+                },
+                {
+                    "name": "probs",
+                    "scale": {},
+                    "columns": [["vote_prob", {"continuous": True}]],
+                },
+            ]
+        }
+    )
+    df = pd.DataFrame(
+        {
+            "draw": [0] * 4,
+            "gender": ["Female", "Male", "Female", "Male"],
+            "vote_prob": [2.0, 4.0, 6.0, 8.0],
+        }
+    )
+    ppd = soft_validate(
+        {
+            "res_col": "vote_prob",
+            "factor_cols": ["gender"],
+            "convert_res": "continuous",
+            "plot": "boxplots",
+        },
+        PlotDescriptor,
+    )
+
+    pi = pp_transform_data(pl.LazyFrame(df), data_meta, ppd)
+
+    assert len(pi.data) > 0
+    by_gender = dict(zip(pi.data["gender"], pd.to_numeric(pi.data[pi.value_col], errors="raise")))
+    assert by_gender["Female"] == pytest.approx(4.0)
+    assert by_gender["Male"] == pytest.approx(6.0)
+
+
 def test_get_plot_fn_builds_chart_from_plot_input() -> None:
     """`get_plot_fn` returns the plot function, callable with a PlotInput plus plot kwargs."""
 


### PR DESCRIPTION
Since #62, `convert_res: continuous` nulls every row of a natively-continuous column: `replace_strict({}, default=None)` maps everything to null and the companion null-filter then empties the frame. Both `/plot` and `/plot-data` have returned empty grids for these descriptors in prod since 2026-07-22.

Guarding on "is the category map empty" was too narrow — a column can carry categories it has no business having — so the rule is enforced on the annotation instead:

**`continuous` and `categories` are exclusive: a column declaring both fails to load.** The check is in `ColumnMeta.check_categorical` and, unlike the rest of that validator, fires in soft mode too — every io load path goes through `soft_validate`, so a soft-only check would never fire on a real load.

**A column's own type declaration overrides the block scale's.** Nobody writes both flags on one column; they write `{"continuous": true}` under a `scale` that carries `categories`. `merge_scale_with_columns` now drops the inherited counterpart in that case, so the error is left for the case it was written for: both asserted at the same level.

**`datetime` is orthogonal to both.** It describes parsing, and parsed dates get bucketed into categories — the documented parse-then-bucket idiom (`test_category_inference_datetime_dtype_formats_human`). A datetime column can be categorical; it just can't be continuous *and* categorical.

### Consequences

- `ColumnMeta.is_categorical` (`categories is not None and not continuous`) replaces five open-coded, mutually inconsistent versions of this question across `pp/matching.py` and `tools/explorer.py`.
- `convert_res` now: maps a categorical (unchanged #62 semantics — nonresponse → null); errors on a plain `datetime`; parses anything continuous-or-numeric; errors on a column that is neither, instead of casting it to all-null. Parsing skips the String hop on numeric dtypes (**87 → 25 ms per million rows**) and lands in `Float64`, so values above ~7 significant digits stop rounding (`16777217` was becoming `16777216`).
- An annotated `val_range` survives `convert_res`; an unannotated one stays unset rather than being fabricated as `(0, 1)`.
- Descriptor `col_meta` overrides are revalidated. `model_copy(update=...)` skips validators, so `{"col_meta": {"q": {"continuous": true}}}` on a categorical column used to build the contradictory state and silently empty the plot; it now raises naming the column's categories. Use `convert_res` for that, not an override.
- `_question_meta_clone` clears `datetime` alongside `continuous`: the synthetic `question` column holds column names.
- The maxdiff create block gave the set-index column the topic list as `categories` while forcing `continuous`. It holds the version number the respondent saw, so forcing `continuous` is now enough — it simply doesn't inherit the scale's topics, which belong on the best/worst columns that actually contain them.

### Corpus impact

Scanned every parquet-embedded meta under `~/salk` (1250 with an stk footer) plus all annotation JSONs, comparing load success against `main`. One genuine violation: lt's `Q2status`, `continuous: true` + `categories: "infer"` on a 5-point living-standard rating — an ordinal scale, so it is now `categories: "infer"` + `ordered: true`. Fixed outside this PR in `sandbox/lithuania/data/lt_meta.json` and in the three stored artifacts carrying the old meta (`lt_dashboard/files/lt_model.parquet`, `census/lithuania/results/lt_boot.parquet`, one sandbox run dir); data untouched, those columns were already `int64` 1-5. **Net regressions vs `main`: 0.**

### Tests

Continuous res col round-trips its values (float column and one stored as a categorical); a column declaring `continuous` under a categorical scale loads as continuous while its siblings stay categorical; same-level contradiction is rejected at load; the datetime parse-then-bucket column still converts through its categories; plain datetime and uninterpretable columns error; `val_range` declared vs undeclared; full precision; contradictory `col_meta` override raises; `_question_meta_clone` is nominal.

Found while recapturing dms parity fixtures for the vega-retirement flip — the boxplots/density/maxdiff continuous combos all came back with 0 cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)