### PR TITLE
rank_columns: don't ship every panel's rows in every payload cell

### DIFF
--- a/salk_toolkit/plots.py
+++ b/salk_toolkit/plots.py
@@ -522,12 +522,24 @@ def rank_columns(
     labels = [str(c) for c in utils.get_categories(p.data[xcol].dtype)]
     data = p.data.assign(**{xcol: pd.Categorical(p.data[xcol], labels, ordered=True)})
 
-    # Complete the (rank x stack) grid with explicit zeros, then normalize the weighted counts
+    # Complete the (rank x stack) grid with explicit zeros, then normalize the weighted counts.
+    # The completion is meant to be *within* a panel, but `observed=False` spans every key it is
+    # given, so it also reinstates outer-factor levels the frame carries no rows for. On a frame
+    # already narrowed to one panel - which is exactly how `create_plot_payload` builds a payload,
+    # cell by cell - those are pure noise, and they land on the wire: an 18-topic maxdiff x 13
+    # parties shipped 4212 rows per cell where 234 were the cell's own. So drop the panels that
+    # carry no weight. Panels that do carry weight are untouched, hence so is the faceted
+    # (single-frame) path, where every panel has weight by construction.
     gcols = p.outer_factors + [xcol, f0.col]
     ndata = data.groupby(gcols, observed=False)[p.value_col].sum().rename("share").reset_index()
     denom_cols = list(p.outer_factors)
-    totals = ndata.groupby(denom_cols, observed=False)["share"].transform("sum") if denom_cols else ndata["share"].sum()
-    ndata["share"] = ndata["share"] / (totals if denom_cols else totals or 1)
+    if denom_cols:
+        totals = ndata.groupby(denom_cols, observed=False)["share"].transform("sum")
+        live = totals > 0
+        ndata, totals = ndata.loc[live].copy(), totals[live]
+    else:
+        totals = ndata["share"].sum() or 1
+    ndata["share"] = ndata["share"] / totals
 
     # Stack order follows the facet's category order; y0/y1 computed manually since the geometry
     # below needs explicit rects rather than an ordinal band stack

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -418,6 +418,34 @@ class TestPlots:
                 cap = 2.0 / n_ranks
                 assert panel["y1"].max() <= cap + 1e-9  # height capped, overflow went to width
 
+    def test_rank_columns_payload_cell_carries_only_its_own_panel(self) -> None:
+        """Each payload cell holds one panel's rows, not every panel's completed with nulls."""
+        config = {
+            "res_col": "thermometer",
+            "facet_dims": ["party_preference", "question"],
+            "internal_facet": True,
+            "plot": "rank_columns",
+            "filter": {},
+        }
+        from salk_toolkit.pp import create_plot_payload, pp_transform_data
+
+        ldf, full_meta = read_parquet_with_metadata(str(self.data_file), lazy=True)
+        assert full_meta is not None and full_meta.data is not None
+        ppd = soft_validate(config, PlotDescriptor)
+        payload = create_plot_payload(pp_transform_data(ldf, full_meta.data, ppd), ppd)
+
+        assert payload["outer_factors"] == ["question"]
+        cells = [c for row in payload["cells"] for c in row]
+        assert len(cells) > 1  # a single-cell grid could not show the duplication either way
+        n_ranks = len(set(cells[0]["data"][payload["cat_col"]]))
+        n_stack = len(payload["facets"][0]["order"])
+        for cell in cells:
+            # RED before the fix: every panel's rows, i.e. len(cells) x this
+            assert set(cell["data"]["question"]) == {cell["keys"]["question"]}
+            assert len(cell["data"]["share"]) == n_ranks * n_stack
+            # ...and no all-null rows left behind by the grid completion (share was 0/0)
+            assert all(v is not None for v in cell["data"]["share"])
+
     def test_diff_columns(self, recompute):
         """Test difference column plots."""
         config = {


### PR DESCRIPTION
## The problem

`create_plot_payload` builds a payload **cell by cell**, calling the plot function with the frame already narrowed to one panel. `rank_columns` then completes its (rank × stack) grid with `observed=False` — but that spans every groupby key it is given, the outer factors included, so it reinstates all the *other* panels' rows as well: null `share` (0/0 — their weight isn't in this frame), null `y0`/`y1`, and geometry nothing draws.

Measured on the live plots-API, `maxdiff_score` × `party_preference` for the 18-topic Estonian maxdiff (modelrun 25):

| | rows/cell | own rows | `/plot-data` | `/plot` |
|---|---|---|---|---|
| before | 4212 | 234 | 6.0 MB, ~7 s | 13.8 MB, ~8.7 s |

An 18× inflation, and it is the whole reason the plot feels like it hangs in the DMS explorer — a 20-item battery on modelrun 173 takes 3–13 s for 8 MB, while the client-side parse + render-input + option build for the same payload is ~50 ms.

On the test battery in this repo (8 panels): **704 rows/cell and 463 KB → 88 and 84 KB.**

## The fix

The function already computes a per-panel denominator (`totals`) to normalize the shares. Panels whose total weight is zero are the phantom ones, so drop them there — three lines, no new grouping pass.

Panels that *do* carry weight are untouched, so the faceted single-frame path — where every panel has weight by construction — is unchanged: `test_rank_columns`' reference chart still matches exactly, byte for byte.

## Compatibility

Consumers that filtered the null rows client-side keep working — there are simply none left to filter. (The DMS/periskoop ECharts renderer filters on `y1 != null`; after this the filter is a no-op.)

## Tests

New `test_rank_columns_payload_cell_carries_only_its_own_panel`: each payload cell holds exactly `n_ranks × n_stack` rows, all from its own panel, none null. Red before the fix (`assert {'EKRE', 'Eesti 200', 'Keskerakond', …} == {'Keskerakond'}`).

`tests/test_plots.py` + `tests/test_plot_payload.py`: 100 passed. The one failure, `test_facet_dist`, is pre-existing and fails identically on `main`. `ruff check` / `ruff format --check` clean; `pyright` reports the same 3 pre-existing errors in `plots.py` as `main`, no new ones.